### PR TITLE
Filter pen logical collections from composite digitizer HID trees

### DIFF
--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -575,6 +575,9 @@ static void Handle_RemovalCallback(
 ) {
     printf("%s(context: %p, result: %p, sender: %p, device: %p).\n",
         __PRETTY_FUNCTION__, inContext, (void *) inResult, inSender, (void*) inIOHIDDeviceRef);
+
+    if (!gQueue) return;
+
     IOHIDQueueStop(gQueue);
     CFRelease(gQueue);
     gQueue = NULL;

--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -181,6 +181,35 @@ void StoreInputValue(IOHIDValueRef hidValue) {
 
 
 
+/**
+ Check whether a logical collection contains pen-specific HID usages
+ (TipPressure, BarrelPressure, XTilt, YTilt, BarrelSwitch, Eraser).
+ Returns TRUE if at least one pen-specific element is found.
+ */
+static Boolean IsPenCollection(IOHIDElementRef collection) {
+    CFArrayRef children = IOHIDElementGetChildren(collection);
+    if (!children) return FALSE;
+    for (CFIndex i = 0; i < CFArrayGetCount(children); i++) {
+        IOHIDElementRef child = (IOHIDElementRef)CFArrayGetValueAtIndex(children, i);
+        CFIndex page  = IOHIDElementGetUsagePage(child);
+        CFIndex usage = IOHIDElementGetUsage(child);
+        if (page == kHIDPage_Digitizer) {
+            switch (usage) {
+                case kHIDUsage_Dig_TipPressure:    // 0x30
+                case kHIDUsage_Dig_BarrelPressure: // 0x31
+                case kHIDUsage_Dig_XTilt:          // 0x3D
+                case kHIDUsage_Dig_YTilt:          // 0x3E
+                case kHIDUsage_Dig_BarrelSwitch:   // 0x44
+                case kHIDUsage_Dig_Eraser:         // 0x45
+                    return TRUE;
+                default:
+                    break;
+            }
+        }
+    }
+    return FALSE;
+}
+
 
 /**
  We need to inspect the HID tree as a whole once to see which elements are grouped into logical groups of touch data.
@@ -221,6 +250,14 @@ void IdentifyElements(IOHIDElementRef anyElement, Boolean printTree) {
         IOHIDElementCollectionType collectionType = IOHIDElementGetCollectionType(element);
         
         if (type == kIOHIDElementTypeCollection && collectionType == kIOHIDElementCollectionTypeLogical) {
+
+            // skip logical collections that contain pen-specific elements
+            // (pressure, tilt, barrel) so only finger-touch collections
+            // feed into the mouse mapping logic
+            if (IsPenCollection(element)) {
+                continue;
+            }
+
             CFArrayAppendValue(gTouchCollectionElements, element);
             
             if (printTree) {


### PR DESCRIPTION
Thank you for this useful tool — it has been great for adding touch support to external monitors.

## Summary

Composite digitizers (e.g. Wacom-based touchscreens with integrated active pen) can expose pen and touch data within the same HID application collection. Without filtering, pen-specific logical collections — containing pressure, tilt, and barrel elements — end up being treated as touch contacts, producing incorrect coordinates.

This PR adds a small pen-collection filter in `IdentifyElements()` so that only finger-touch logical collections feed into the mouse-mapping logic.

## Changes

- Add `IsPenCollection()` — inspects direct children of a logical collection for pen-only Digitizer-page usages (`TipPressure`, `BarrelPressure`, `XTilt`, `YTilt`, `BarrelSwitch`, `Eraser`)
- Call `IsPenCollection()` in `IdentifyElements()` to skip pen collections before they are appended to `gTouchCollectionElements`
- Guard `Handle_RemovalCallback` against NULL `gQueue` — composite digitizers trigger multiple removal callbacks per disconnect; without the guard, the second call passes NULL to `IOHIDQueueStop`/`CFRelease`, causing a crash

## Notes

- **No vendor/product ID hardcoding** — the filter is usage-based and benefits any composite digitizer, following the existing device-matching philosophy
- **Only direct children inspected** — matches the depth used by `IdentifyElements()` itself
- **Conservative usage set** — `InRange` (0x32) is intentionally excluded because it appears in both pen and touch collections
- **No effect on single-digitizer touchscreens** — devices without pen collections pass through unchanged

## Tested with

- Lenovo ThinkVision M14t Gen2 (Wacom digitizer, VID `0x2D1F` / PID `0x53D1`)
- Single-touch, multi-touch, and pinch-to-zoom all working

## Test plan

- [ ] Verify single-finger touch → mouse cursor moves correctly
- [ ] Verify multi-touch pinch-to-zoom works
- [ ] Verify existing single-digitizer touchscreens are unaffected (no pen collections → no filtering)
- [ ] Verify cable disconnect does not crash the app