### PR TITLE
Add Windows Touch Mode, per-digitizer calibration, and HID event logging

### DIFF
--- a/Touch Up/AppDelegate.swift
+++ b/Touch Up/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var activationMenuItem: NSMenuItem!
     
     var observers = [AnyCancellable]()
+    private var settingsWindowWasVisibleBeforeDebugOverlay = false
     
     
     
@@ -93,16 +94,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func showDebugOverlay(on screen: TUCScreen? = nil, digitizer locationID: HIDLocationID? = nil) {
-        let preState = self.model.isPublishingMouseEventsEnabled
+        guard let screen = screen ?? TUCScreen.allScreens().first else { return }
+
+        settingsWindowWasVisibleBeforeDebugOverlay = settingsWindow.isVisible
+        if settingsWindowWasVisibleBeforeDebugOverlay {
+            settingsWindow.orderOut(nil)
+        }
+
+        self.debugOverlay.publishingStateBeforeOverlay = self.model.isPublishingMouseEventsEnabled
         self.model.isPublishingMouseEventsEnabled = false
         DebugOverlay.completion = {[unowned self] in
             self.debugOverlay.close()
-            self.model.isPublishingMouseEventsEnabled = preState
+            if self.settingsWindowWasVisibleBeforeDebugOverlay {
+                self.settingsWindow.makeVisible()
+                self.settingsWindowWasVisibleBeforeDebugOverlay = false
+            }
         }
-        
-        if let screen = screen ?? TUCScreen.allScreens().first {
-            self.debugOverlay.makeVisible(onScreen: screen, digitizerLocationID: locationID)
-        }
+
+        self.debugOverlay.makeVisible(onScreen: screen, digitizerLocationID: locationID)
     }
 }
 

--- a/Touch Up/DebugOverlay.swift
+++ b/Touch Up/DebugOverlay.swift
@@ -14,6 +14,7 @@ import TouchUpCore
 class DebugOverlay: NSWindow {
     
     var model: TouchUp?
+    var publishingStateBeforeOverlay: Bool?
     static var completion: (()->Void)?
     
     private static func constructView(model: TouchUp, locationID: HIDLocationID?) -> DebugView {
@@ -71,6 +72,11 @@ class DebugOverlay: NSWindow {
     }
     
     override func close() {
+        self.model?.calibrationBypassLocationID = nil
+        if let publishingStateBeforeOverlay {
+            self.model?.isPublishingMouseEventsEnabled = publishingStateBeforeOverlay
+            self.publishingStateBeforeOverlay = nil
+        }
         if let controller = self.contentViewController {
             self.level = .normal
             self.setIsVisible(true)

--- a/Touch Up/DebugView.swift
+++ b/Touch Up/DebugView.swift
@@ -18,11 +18,29 @@ struct DebugView: View {
     let closeAction: ()->Void
     
     var pixelsPerMM: CGFloat
+
+    @State private var calibrationSamples = [(target: CGPoint, observed: CGPoint)]()
+    @State private var currentCalibrationIndex = 0
+    @State private var processedCalibrationTouches = Set<String>()
+    @State private var isCalibrating = false
+    @State private var calibrationMessage: String?
+
+    private let calibrationTargets = [
+        CGPoint(x: 0.1, y: 0.1),
+        CGPoint(x: 0.9, y: 0.1),
+        CGPoint(x: 0.9, y: 0.9),
+        CGPoint(x: 0.1, y: 0.9),
+        CGPoint(x: 0.5, y: 0.5)
+    ]
     
     init(model: TouchUp, locationID: HIDLocationID?, closeAction: @escaping ()->Void) {
         self.model = model
         self.locationID = locationID
-        self.pixelsPerMM = model.touchscreen(forLocationID: 0)?.pixelsPerMM() ?? 30
+        if let locationID, let screen = model.touchscreen(forLocationID: locationID) {
+            self.pixelsPerMM = screen.pixelsPerMM()
+        } else {
+            self.pixelsPerMM = 30
+        }
         self.closeAction = closeAction
     }
     
@@ -61,6 +79,8 @@ struct DebugView: View {
                 .frame(maxWidth:.infinity, maxHeight: .infinity)
                 .overlay(GeometryReader { geo in
                     ZStack(alignment: .bottom) {
+                        calibrationTarget(in: geo.size)
+
                         ForEach(allTouches, id:\.uuid) { point in
                             Circle()
                                 .foregroundColor(colorForPhase(point.phase))
@@ -81,28 +101,158 @@ struct DebugView: View {
                 })
             
             
-            Button(action: {
-                closeAction()
-            }, label: {
-                HStack {
-                    Text("Close overlay with ")
-                    Label("W", systemImage: "command.square.fill")
-                    Text("or by mouse-clicking here")
-                }
-                .font(.largeTitle)
-                .modify {
-                    if #available(macOS 13.0, *) {
-                        $0.fontDesign(.rounded)
-                    } else { $0 }
-                }
-            })
-            .foregroundColor(.gray)
-            .buttonStyle(.borderless)
-            .keyboardShortcut(KeyEquivalent("w"), modifiers: [.command])
-            .padding(.bottom, 140)
+            VStack(spacing: 16) {
+                calibrationControls
+
+                Button(action: {
+                    closeAction()
+                }, label: {
+                    HStack {
+                        Text("Close overlay with ")
+                        Label("W", systemImage: "command.square.fill")
+                        Text("or by mouse-clicking here")
+                    }
+                    .font(.largeTitle)
+                    .modify {
+                        if #available(macOS 13.0, *) {
+                            $0.fontDesign(.rounded)
+                        } else { $0 }
+                    }
+                })
+                .foregroundColor(.gray)
+                .buttonStyle(.borderless)
+                .keyboardShortcut(KeyEquivalent("w"), modifiers: [.command])
+            }
+            .padding(.bottom, 120)
+        }
+        .onReceive(model.$touches) { touches in
+            processCalibrationTouches(touches)
         }
         
-        
+    }
+
+    @ViewBuilder
+    private func calibrationTarget(in size: CGSize) -> some View {
+        if isCalibrating && currentCalibrationIndex < calibrationTargets.count {
+            let target = calibrationTargets[currentCalibrationIndex]
+            let x = target.x * size.width
+            let y = target.y * size.height
+
+            ZStack {
+                Circle()
+                    .stroke(Color.white, lineWidth: 3)
+                    .frame(width: 72, height: 72)
+                Rectangle()
+                    .fill(Color.white)
+                    .frame(width: 96, height: 3)
+                Rectangle()
+                    .fill(Color.white)
+                    .frame(width: 3, height: 96)
+            }
+            .position(x: x, y: y)
+        }
+    }
+
+    @ViewBuilder
+    private var calibrationControls: some View {
+        if let locationID = locationID {
+            VStack(spacing: 10) {
+                if isCalibrating {
+                    Text("Calibration \(currentCalibrationIndex + 1) of \(calibrationTargets.count)")
+                        .font(.title2)
+                    Button("Cancel Calibration") {
+                        stopCalibration()
+                    }
+                } else {
+                    if let message = calibrationMessage {
+                        Text(message)
+                            .font(.headline)
+                    } else if let calibration = model.digitizerConfigs[locationID]?.calibration {
+                        Text(String(format: "Calibrated: mean %.1f pt, max %.1f pt",
+                                    calibration.meanError * calibrationErrorScale,
+                                    calibration.maxError * calibrationErrorScale))
+                            .font(.headline)
+                    } else {
+                        Text("Not calibrated")
+                            .font(.headline)
+                    }
+
+                    HStack(spacing: 16) {
+                        Button("Start Calibration") {
+                            startCalibration(for: locationID)
+                        }
+                        Button("Reset Calibration") {
+                            model.setCalibration(nil, forDigitizer: locationID)
+                            calibrationMessage = "Calibration reset"
+                        }
+                    }
+                }
+            }
+            .foregroundColor(.white)
+            .padding(14)
+            .background(Color.black.opacity(0.55))
+            .cornerRadius(8)
+        }
+    }
+
+    private func startCalibration(for locationID: HIDLocationID) {
+        calibrationSamples.removeAll()
+        processedCalibrationTouches.removeAll()
+        currentCalibrationIndex = 0
+        calibrationMessage = nil
+        isCalibrating = true
+        model.calibrationBypassLocationID = locationID
+    }
+
+    private func stopCalibration() {
+        isCalibrating = false
+        model.calibrationBypassLocationID = nil
+    }
+
+    private func processCalibrationTouches(_ touches: [TUCTouch]) {
+        guard isCalibrating,
+              let locationID = locationID,
+              currentCalibrationIndex < calibrationTargets.count
+        else { return }
+
+        guard let touch = touches.first(where: {
+            $0.locationID == locationID &&
+            $0.phase == .ended &&
+            !processedCalibrationTouches.contains($0.uuid.uuidString)
+        }) else { return }
+
+        processedCalibrationTouches.insert(touch.uuid.uuidString)
+        calibrationSamples.append((
+            target: calibrationTargets[currentCalibrationIndex],
+            observed: touch.location
+        ))
+        currentCalibrationIndex += 1
+
+        if currentCalibrationIndex == calibrationTargets.count {
+            finishCalibration(for: locationID)
+        }
+    }
+
+    private func finishCalibration(for locationID: HIDLocationID) {
+        model.calibrationBypassLocationID = nil
+        isCalibrating = false
+
+        guard let calibration = TouchCalibration.fit(samples: calibrationSamples) else {
+            calibrationMessage = "Calibration failed"
+            return
+        }
+
+        model.setCalibration(calibration, forDigitizer: locationID)
+        calibrationMessage = String(format: "Calibration saved: mean %.1f pt, max %.1f pt",
+                                    calibration.meanError * calibrationErrorScale,
+                                    calibration.maxError * calibrationErrorScale)
+    }
+
+    private var calibrationErrorScale: CGFloat {
+        guard let locationID,
+              let screen = model.touchscreen(forLocationID: locationID)
+        else { return 1 }
+        return max(screen.frame.size.width, screen.frame.size.height)
     }
 }
 

--- a/Touch Up/Digitizer.swift
+++ b/Touch Up/Digitizer.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 
 /// Per-digitizer settings, keyed by `HIDLocationID` and persisted to `UserDefaults`.
 ///
-/// Only the screen identity (`screenID` + `screenUUID`) and `additionalRotation` are stored.
+/// Screen identity, rotation, and optional coordinate calibration are stored.
 /// The actually resolved `TUCScreen` is *not* kept here: the screen list is rebuilt from
 /// scratch on every display reconfiguration, so any held reference would go stale. The screen
 /// is therefore resolved lazily from this identity (see `TouchUp.resolvedMapping(forLocationID:)`).
@@ -20,6 +20,101 @@ struct DigitizerConfig: Codable, Hashable {
     /// Stable per physical panel across launches/rearrangements. Stronger match.
     var screenUUID: String?
     var additionalRotation: CGFloat = 0
+    var calibration: TouchCalibration?
+}
+
+struct TouchCalibration: Codable, Hashable {
+    var a: CGFloat
+    var b: CGFloat
+    var c: CGFloat
+    var d: CGFloat
+    var e: CGFloat
+    var f: CGFloat
+    var meanError: CGFloat
+    var maxError: CGFloat
+
+    func apply(to point: CGPoint) -> CGPoint {
+        CGPoint(
+            x: min(1, max(0, a * point.x + b * point.y + c)),
+            y: min(1, max(0, d * point.x + e * point.y + f))
+        )
+    }
+
+    static func fit(samples: [(target: CGPoint, observed: CGPoint)]) -> TouchCalibration? {
+        guard samples.count >= 3 else { return nil }
+
+        var ata = Array(repeating: Array(repeating: CGFloat(0), count: 3), count: 3)
+        var bx = Array(repeating: CGFloat(0), count: 3)
+        var by = Array(repeating: CGFloat(0), count: 3)
+
+        for sample in samples {
+            let row = [sample.observed.x, sample.observed.y, CGFloat(1)]
+            for i in 0..<3 {
+                bx[i] += row[i] * sample.target.x
+                by[i] += row[i] * sample.target.y
+                for j in 0..<3 {
+                    ata[i][j] += row[i] * row[j]
+                }
+            }
+        }
+
+        guard let x = solve3x3(ata, bx), let y = solve3x3(ata, by) else {
+            return nil
+        }
+
+        var errors = [CGFloat]()
+        let calibration = TouchCalibration(
+            a: x[0], b: x[1], c: x[2],
+            d: y[0], e: y[1], f: y[2],
+            meanError: 0, maxError: 0
+        )
+
+        for sample in samples {
+            let corrected = calibration.apply(to: sample.observed)
+            errors.append(hypot(corrected.x - sample.target.x, corrected.y - sample.target.y))
+        }
+
+        return TouchCalibration(
+            a: x[0], b: x[1], c: x[2],
+            d: y[0], e: y[1], f: y[2],
+            meanError: errors.reduce(0, +) / CGFloat(errors.count),
+            maxError: errors.max() ?? 0
+        )
+    }
+
+    private static func solve3x3(_ matrix: [[CGFloat]], _ vector: [CGFloat]) -> [CGFloat]? {
+        var a = matrix
+        var b = vector
+
+        for column in 0..<3 {
+            var pivot = column
+            for row in column..<3 where abs(a[row][column]) > abs(a[pivot][column]) {
+                pivot = row
+            }
+            guard abs(a[pivot][column]) > 0.000001 else { return nil }
+
+            if pivot != column {
+                a.swapAt(pivot, column)
+                b.swapAt(pivot, column)
+            }
+
+            let divisor = a[column][column]
+            for j in column..<3 {
+                a[column][j] /= divisor
+            }
+            b[column] /= divisor
+
+            for row in 0..<3 where row != column {
+                let factor = a[row][column]
+                for j in column..<3 {
+                    a[row][j] -= factor * a[column][j]
+                }
+                b[row] -= factor * b[column]
+            }
+        }
+
+        return b
+    }
 }
 
 /// How confidently a digitizer's stored screen identity could be resolved against the

--- a/Touch Up/DigitizerMappingView.swift
+++ b/Touch Up/DigitizerMappingView.swift
@@ -44,19 +44,6 @@ struct DigitizerMappingView: View {
                     .foregroundColor(.secondary)
 
                 Spacer()
-
-                Button(action: {
-                    let screen = model.resolvedMapping(forLocationID: digitizer.locationID).screen
-                    (NSApp.delegate as? AppDelegate)?.showDebugOverlay(on: screen, digitizer: digitizer.locationID)
-                }, label: {
-                    HStack(spacing: 2) {
-                        Image(systemName: "arrow.up.forward.app.fill")
-                        Text("Test")
-                    }
-                    .font(.caption)
-                })
-                .foregroundColor(.accentColor)
-                .buttonStyle(.plain)
             }
 
             HStack(spacing: 8) {
@@ -79,6 +66,20 @@ struct DigitizerMappingView: View {
 
                 screenPicker(for: digitizer)
             }
+
+            Button(action: {
+                let screen = model.resolvedMapping(forLocationID: digitizer.locationID).screen
+                (NSApp.delegate as? AppDelegate)?.showDebugOverlay(on: screen, digitizer: digitizer.locationID)
+            }, label: {
+                HStack {
+                    Image(systemName: "scope")
+                    Text("Test / Calibrate Touchscreen")
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            })
+            .buttonStyle(BorderedButtonStyle())
+            .controlSize(.large)
         }
     }
 

--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -40,7 +40,6 @@ struct SettingsView: View {
     
     var gestureSettings: some View {
         Group {
-            
             let mode_ = Binding {
                 model.isClickOnLiftEnabled ? 2 : (model.isScrollingWithOneFingerEnabled ? 0 : 1)
             } set: { value in
@@ -55,11 +54,13 @@ struct SettingsView: View {
             } label: {
                 SettingsExplanationLabel(labels: ("On Finger Drag", "Specify which action should occur when dragging one finger on the touch screen."))
             }
+            .disabled(model.isWindowsTouchModeEnabled)
 
             
             Toggle(isOn: $model.isSecondaryClickEnabled) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.isSecondaryClickEnabled))
             }
+            .disabled(model.isWindowsTouchModeEnabled)
             
             Toggle(isOn: $model.isMagnificationEnabled) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.isMagnificationEnabled))
@@ -67,6 +68,11 @@ struct SettingsView: View {
             
             Toggle(isOn: $model.isClickWindowToFrontEnabled) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.isClickWindowToFrontEnabled))
+            }
+            .disabled(model.isWindowsTouchModeEnabled)
+
+            Toggle(isOn: $model.isWindowsTouchModeEnabled) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.isWindowsTouchModeEnabled))
             }
         }
     }
@@ -81,6 +87,11 @@ struct SettingsView: View {
             Slider(value: $model.doubleClickDistance, in: 0...8, step: 1) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.doubleClickDistance))
             }
+
+            Slider(value: $model.windowsTouchModeSingleFingerDistance, in: 0...30, step: 1) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.windowsTouchModeSingleFingerDistance))
+            }
+            .disabled(!model.isWindowsTouchModeEnabled)
         }
     }
     
@@ -96,6 +107,10 @@ struct SettingsView: View {
             
             Toggle(isOn: $model.ignoreOriginTouches) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.ignoreOriginTouches))
+            }
+
+            Toggle(isOn: $model.isTouchEventLoggingEnabled) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.isTouchEventLoggingEnabled))
             }
 
             Toggle(isOn: $model.areAdditionalDigitizerRotationSettingsVisible) {

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -23,13 +23,16 @@ class TouchUp: NSObject, ObservableObject {
     
     @Published var holdDuration: TimeInterval = 0.1
     @Published var doubleClickDistance: CGFloat = 3 //mm
+    @Published var windowsTouchModeSingleFingerDistance: CGFloat = 0
     @Published var errorResistance: NSInteger = 0 // num of Reports to wait before cancelling a touch
     @Published var ignoreOriginTouches: Bool = false
+    @Published var isTouchEventLoggingEnabled = false
     
     @Published var isScrollingWithOneFingerEnabled = false
     @Published var isSecondaryClickEnabled = false
     @Published var isMagnificationEnabled = false
     @Published var isClickWindowToFrontEnabled = false
+    @Published var isWindowsTouchModeEnabled = false
     @Published var isClickOnLiftEnabled = false
 
     @Published var areAdditionalDigitizerRotationSettingsVisible = false
@@ -49,6 +52,9 @@ class TouchUp: NSObject, ObservableObject {
     /// `CGDirectDisplayID` of the screen that connected most recently. Used as the implicit
     /// fallback target when a digitizer has no (matching) stored screen identity.
     var idOfLastAddedScreen: UInt?
+
+    /// Temporarily bypasses saved calibration while a digitizer is being recalibrated.
+    var calibrationBypassLocationID: HIDLocationID?
 
 
     @Published var isAccessibilityAccessGranted = false
@@ -120,29 +126,37 @@ extension TouchUp {
         defaults.register(defaults: [
             "holdDuration" : 0.1,
             "doubleClickDistance" : 8,
+            "windowsTouchModeSingleFingerDistance" : 0,
             "errorResistance" : 4,
             "ignoreOriginTouches" : true,
+            "isTouchEventLoggingEnabled" : false,
 
             "isScrollingWithOneFingerEnabled" : true,
             "isSecondaryClickEnabled" : true,
             "isMagnificationEnabled" : true,
             "isClickWindowToFrontEnabled" : false,
+            "isWindowsTouchModeEnabled" : false,
             "isClickOnLiftEnabled" : false,
             "areAdditionalDigitizerRotationSettingsVisible" : false
         ])
         
         holdDuration = defaults.double(forKey: "holdDuration")
         doubleClickDistance = defaults.double(forKey: "doubleClickDistance")
+        windowsTouchModeSingleFingerDistance = defaults.double(forKey: "windowsTouchModeSingleFingerDistance")
         errorResistance = defaults.integer(forKey: "errorResistance")
         ignoreOriginTouches = defaults.bool(forKey: "ignoreOriginTouches")
+        isTouchEventLoggingEnabled = defaults.bool(forKey: "isTouchEventLoggingEnabled")
 
 
         self.observers = [
             $isPublishingMouseEventsEnabled.assign(to: \.postMouseEvents, on: touchManager),
             $holdDuration.assign(to: \.holdDuration, on: touchManager),
             $doubleClickDistance.assign(to: \.doubleClickTolerance, on: touchManager),
+            $windowsTouchModeSingleFingerDistance.assign(to: \.windowsTouchModeSingleFingerDistance, on: touchManager),
             $errorResistance.assign(to: \.errorResistance, on: touchManager),
-            $ignoreOriginTouches.assign(to: \.ignoreOriginTouches, on: touchManager)
+            $ignoreOriginTouches.assign(to: \.ignoreOriginTouches, on: touchManager),
+            $isTouchEventLoggingEnabled.assign(to: \.logTouchEvents, on: touchManager),
+            $isWindowsTouchModeEnabled.assign(to: \.usesWindowsTouchMode, on: touchManager)
         ]
         
         
@@ -151,6 +165,7 @@ extension TouchUp {
         isSecondaryClickEnabled = defaults.bool(forKey: "isSecondaryClickEnabled")
         isMagnificationEnabled = defaults.bool(forKey: "isMagnificationEnabled")
         isClickWindowToFrontEnabled = defaults.bool(forKey: "isClickWindowToFrontEnabled")
+        isWindowsTouchModeEnabled = defaults.bool(forKey: "isWindowsTouchModeEnabled")
         isClickOnLiftEnabled = defaults.bool(forKey: "isClickOnLiftEnabled")
         areAdditionalDigitizerRotationSettingsVisible = defaults.bool(forKey: "areAdditionalDigitizerRotationSettingsVisible")
     }
@@ -161,13 +176,16 @@ extension TouchUp {
         
         defaults.set(holdDuration, forKey: "holdDuration")
         defaults.set(doubleClickDistance, forKey: "doubleClickDistance")
-        defaults.set(errorResistance, forKey: "$errorResistance")
+        defaults.set(windowsTouchModeSingleFingerDistance, forKey: "windowsTouchModeSingleFingerDistance")
+        defaults.set(errorResistance, forKey: "errorResistance")
         defaults.set(ignoreOriginTouches, forKey: "ignoreOriginTouches")
+        defaults.set(isTouchEventLoggingEnabled, forKey: "isTouchEventLoggingEnabled")
 
         defaults.set(isScrollingWithOneFingerEnabled, forKey: "isScrollingWithOneFingerEnabled")
         defaults.set(isSecondaryClickEnabled, forKey: "isSecondaryClickEnabled")
         defaults.set(isMagnificationEnabled, forKey: "isMagnificationEnabled")
         defaults.set(isClickWindowToFrontEnabled, forKey: "isClickWindowToFrontEnabled")
+        defaults.set(isWindowsTouchModeEnabled, forKey: "isWindowsTouchModeEnabled")
         defaults.set(isClickOnLiftEnabled, forKey: "isClickOnLiftEnabled")
         defaults.set(areAdditionalDigitizerRotationSettingsVisible, forKey: "areAdditionalDigitizerRotationSettingsVisible")
     }
@@ -225,6 +243,13 @@ extension TouchUp {
     func setRotation(_ rotation: CGFloat, forDigitizer locationID: HIDLocationID) {
         guard var config = digitizerConfigs[locationID] else { return }
         config.additionalRotation = rotation
+        digitizerConfigs[locationID] = config
+        persistMapping(forLocationID: locationID)
+    }
+
+    func setCalibration(_ calibration: TouchCalibration?, forDigitizer locationID: HIDLocationID) {
+        guard var config = digitizerConfigs[locationID] else { return }
+        config.calibration = calibration
         digitizerConfigs[locationID] = config
         persistMapping(forLocationID: locationID)
     }
@@ -305,28 +330,47 @@ extension TouchUp: TUCTouchDelegate {
     func digitizerRotation(forLocationID locationID: UInt32) -> CGFloat {
         digitizerConfigs[locationID]?.additionalRotation ?? 0
     }
+
+    func calibratedRelativePoint(_ point: CGPoint, forLocationID locationID: UInt32) -> CGPoint {
+        if calibrationBypassLocationID == locationID {
+            return point
+        }
+        return digitizerConfigs[locationID]?.calibration?.apply(to: point) ?? point
+    }
     
     func action(for gesture: TUCCursorGesture) -> TUCCursorAction {
         switch gesture {
         case .TUCCursorGestureTouchDown:
+            if isWindowsTouchModeEnabled {
+                return .move
+            }
             return isClickWindowToFrontEnabled ? .moveClickIfNeeded : .move
             
         case .TUCCursorGestureTap:
             return .click
             
         case .TUCCursorGestureLongPress:
-            return .click
+            return isWindowsTouchModeEnabled ? .secondaryClick : .click
             
         case .TUCCursorGestureDrag:
+            if isWindowsTouchModeEnabled {
+                return .drag
+            }
             return isClickOnLiftEnabled ? .pointAndClick : (isScrollingWithOneFingerEnabled ? .scroll : .move)
             
         case .TUCCursorGestureHoldAndDrag:
             return .drag
             
         case .TUCCursorGestureTapSecondFinger:
+            if isWindowsTouchModeEnabled {
+                return .none
+            }
             return isSecondaryClickEnabled ? .secondaryClick : .none
             
         case .TUCCursorGestureTwoFingerDrag:
+            if isWindowsTouchModeEnabled {
+                return .scroll
+            }
             return isScrollingWithOneFingerEnabled ? .drag : .scroll
             
         case .TUCCursorGesturePinch:
@@ -386,6 +430,10 @@ extension TouchUp {
         case \.isClickWindowToFrontEnabled:
             return("Bring Windows to Front",
                    "When touching a window that is not frontmost, bring it to front first. (EXPERIMENTAL)")
+
+        case \.isWindowsTouchModeEnabled:
+            return("Windows Touch Mode",
+                   "Tap to click on release, double-tap to double-click, long-press for secondary click, drag with one finger, and scroll with two fingers.")
             
         case \.isClickOnLiftEnabled:
             return("Point and click",
@@ -398,10 +446,18 @@ extension TouchUp {
         case \.doubleClickDistance:
             return("Double Click Zone",
                    "How many mm can two taps be apart from each other to qualify double click")
+
+        case \.windowsTouchModeSingleFingerDistance:
+            return("Two-Finger Separation",
+                   "In Windows Touch Mode, require more separation before two active contacts start a two-finger gesture.")
             
         case \.ignoreOriginTouches:
             return("Ignore Origin Touches",
                    "If your touchscreen randomly sends coordinate (0,0) in its datastream, toggle this option to make input more stable.")
+
+        case \.isTouchEventLoggingEnabled:
+            return("Log Touch Events",
+                   "Write touch coordinates, recognized gestures, cursor actions, and click counts to the system log.")
             
         case \.errorResistance:
             return("Error Resistance",

--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -13,10 +13,12 @@
 #include <IOKit/hid/IOHIDManager.h>
 
 #include <CoreGraphics/CoreGraphics.h>
+#include <os/log.h>
 
 #pragma mark - Per-Device State
 
 #define kMaxTouchscreens 4
+#define kMaxTrackedTouchCollections 32
 
 typedef struct {
     IOHIDDeviceRef          device;     // unique identity of this HID interface
@@ -43,7 +45,19 @@ typedef struct {
     CFIndex                 contactCount;
     CFIndex                 hybridOffset;
     Boolean                 touchscreenUsesHybridMode;
+    Boolean                 touchCollectionWasActive[kMaxTrackedTouchCollections];
+    CGFloat                 touchCollectionLastX[kMaxTrackedTouchCollections];
+    CGFloat                 touchCollectionLastY[kMaxTrackedTouchCollections];
 } HIDDeviceState;
+
+typedef struct {
+    CGFloat                 x;
+    CGFloat                 y;
+    CFIndex                 contactID;
+    CFIndex                 tipSwitch;
+    CFIndex                 isValid;
+    Boolean                 hasTipSwitch;
+} HIDTouchCollectionData;
 
 static HIDDeviceState gDevices[kMaxTouchscreens];
 static int gDeviceCount = 0;
@@ -55,6 +69,7 @@ static void* gTouchManager;
 static CFRunLoopRef gRunLoopRef;
 
 static IOHIDManagerRef gHidManager;
+static Boolean gLogHIDEvents = false;
 
 // When true, accepted touch interfaces are opened exclusively (seized) so macOS and other
 // apps no longer receive their events — Touch Up becomes the sole handler. Opt-in.
@@ -421,25 +436,18 @@ void PrintTouchCollection(HIDDeviceState *device, IOHIDElementRef collection) {
 }
 
 
-/**
- Dispatches touch data for the given collection, but only if all values needed were received
- */
-
-void DispatchTouchDataForCollection(HIDDeviceState *device, IOHIDElementRef collection) {
+static HIDTouchCollectionData TouchDataForCollection(HIDDeviceState *device, IOHIDElementRef collection) {
+    HIDTouchCollectionData data = {
+        .x = -1,
+        .y = -1,
+        .contactID = 0,
+        .tipSwitch = 0,
+        .isValid = 0,
+        .hasTipSwitch = false
+    };
     
     CFArrayRef children = IOHIDElementGetChildren(collection);
-    
-    CGFloat x = -1;
-    CGFloat y = -1;
-    
-    CFIndex contactID = 0;
-    CFIndex tipSwitch = 0;
-    CFIndex isValid = 0;
-    
-    CFIndex width   = kCFNotFound;
-    CFIndex height  = kCFNotFound;
-    CFIndex azimuth = kCFNotFound;
-    
+
     // get stored values of all touches
     for (CFIndex i=0; i<CFArrayGetCount(children); i++) {
         IOHIDElementRef element = (IOHIDElementRef)CFArrayGetValueAtIndex(children, i);
@@ -454,40 +462,96 @@ void DispatchTouchDataForCollection(HIDDeviceState *device, IOHIDElementRef coll
                     CGFloat min = (CGFloat)IOHIDElementGetLogicalMin(element);
                     CGFloat max = (CGFloat)IOHIDElementGetLogicalMax(element);
                     CGFloat curr = (CGFloat)value;
-                    x = ( (curr - min) / (max - min) ) + min;
+                    data.x = ( (curr - min) / (max - min) ) + min;
                 }
                 
                 else if (usage == kHIDUsage_GD_Y) {
                     CGFloat min = (CGFloat)IOHIDElementGetLogicalMin(element);
                     CGFloat max = (CGFloat)IOHIDElementGetLogicalMax(element);
                     CGFloat curr = (CGFloat)value;
-                    y = ( (curr - min) / (max - min) ) + min;
+                    data.y = ( (curr - min) / (max - min) ) + min;
                 }
             } //kHIDPage_GenericDesktop
             
             else if (page == kHIDPage_Digitizer) {
                 if (usage == kHIDUsage_Dig_ContactIdentifier) {
-                    contactID = value;
+                    data.contactID = value;
                 } else if (usage == kHIDUsage_Dig_TipSwitch) {
-                    tipSwitch = value;
+                    data.tipSwitch = value;
+                    data.hasTipSwitch = true;
                 } else if (usage == kHIDUsage_Dig_TouchValid) {
-                    isValid = value;
-                } else if (usage == kHIDUsage_Dig_Width) {
-                    width = value;
-                } else if (usage == kHIDUsage_Dig_Height) {
-                    height = value;
-                } else if (usage == kHIDUsage_Dig_Azimuth) {
-                    azimuth = value;
+                    data.isValid = value;
                 }
             } // kHIDPage_Digitizer
         }
     }
-    TouchInputManagerUpdateTouchPosition(gTouchManager, device->locationID, contactID, x, y, (int)tipSwitch, (int)isValid);
-    
-    //    if (width != kCFNotFound && height != kCFNotFound && azimuth != kCFNotFound) {
-    //        TouchInputManagerUpdateTouchSize(gTouchManager, contactID, (CGFloat)width, (CGFloat)height, (CGFloat)azimuth);
-    //    }
-    
+
+    return data;
+}
+
+
+static void LogTouchDataForCollection(HIDDeviceState *device, HIDTouchCollectionData data, CFIndex collectionIndex, Boolean shouldDispatch, CFIndex effectiveContactID) {
+    if (gLogHIDEvents) {
+        os_log_info(OS_LOG_DEFAULT,
+                    "TouchUp HID collection locationID=0x%{public}08x index=%{public}ld dispatch=%{public}d contact=%{public}ld effectiveContact=%{public}ld tip=%{public}ld valid=%{public}ld x=%{public}.4f y=%{public}.4f",
+                    device->locationID,
+                    (long)collectionIndex,
+                    shouldDispatch,
+                    (long)data.contactID,
+                    (long)effectiveContactID,
+                    (long)data.tipSwitch,
+                    (long)data.isValid,
+                    data.x,
+                    data.y);
+    }
+}
+
+
+static void DispatchTouchData(HIDDeviceState *device, HIDTouchCollectionData data, CFIndex contactID) {
+    TouchInputManagerUpdateTouchPosition(gTouchManager, device->locationID, contactID, data.x, data.y, (int)data.tipSwitch, (int)data.isValid);
+}
+
+
+static Boolean ShouldUseCollectionIndexContactIDs(HIDDeviceState *device, CFIndex numCollections) {
+    // Some parallel touch report descriptors reuse ContactIdentifier=0 for every
+    // logical collection. In that shape the collection slot is the stable identity.
+    return !device->touchscreenUsesHybridMode && numCollections > 1 && device->contactCollectionCount > 1;
+}
+
+
+static void DispatchNonHybridTouches(HIDDeviceState *device, CFIndex numCollections) {
+    Boolean useCollectionIndexContactIDs = ShouldUseCollectionIndexContactIDs(device, numCollections);
+
+    for (CFIndex i=0; i<numCollections; i++) {
+        IOHIDElementRef collection = (IOHIDElementRef)CFArrayGetValueAtIndex(device->touchCollectionElements, i);
+        HIDTouchCollectionData data = TouchDataForCollection(device, collection);
+        Boolean isTrackedCollection = i < kMaxTrackedTouchCollections;
+        Boolean wasActive = isTrackedCollection && device->touchCollectionWasActive[i];
+        Boolean isActive = data.hasTipSwitch ? data.tipSwitch != 0 : i < device->contactCount;
+        Boolean shouldDispatch = isActive || wasActive;
+        CFIndex effectiveContactID = useCollectionIndexContactIDs && isTrackedCollection ? i : data.contactID;
+
+        if (shouldDispatch && !isActive && wasActive) {
+            data.x = device->touchCollectionLastX[i];
+            data.y = device->touchCollectionLastY[i];
+        }
+
+        LogTouchDataForCollection(device, data, i, shouldDispatch, effectiveContactID);
+
+        if (shouldDispatch) {
+            DispatchTouchData(device, data, effectiveContactID);
+        }
+
+        if (isTrackedCollection) {
+            if (isActive) {
+                device->touchCollectionWasActive[i] = true;
+                device->touchCollectionLastX[i] = data.x;
+                device->touchCollectionLastY[i] = data.y;
+            } else if (wasActive) {
+                device->touchCollectionWasActive[i] = false;
+            }
+        }
+    }
 }
 
 
@@ -496,6 +560,29 @@ void DispatchTouches(HIDDeviceState *device) {
     
     CFIndex numCollections = CFArrayGetCount(device->touchCollectionElements);
     CFIndex remainingUpdates = device->contactCount - device->hybridOffset;
+
+    if (gLogHIDEvents) {
+        os_log_info(OS_LOG_DEFAULT,
+                    "TouchUp HID report locationID=0x%{public}08x contactCount=%{public}ld collections=%{public}ld hybridOffset=%{public}ld remaining=%{public}ld hybrid=%{public}d",
+                    device->locationID,
+                    (long)device->contactCount,
+                    (long)numCollections,
+                    (long)device->hybridOffset,
+                    (long)remainingUpdates,
+                    device->touchscreenUsesHybridMode);
+    }
+
+    if (numCollections <= 0) {
+        TouchInputManagerDidProcessReport(gTouchManager, device->locationID);
+        return;
+    }
+
+    if (!device->touchscreenUsesHybridMode) {
+        DispatchNonHybridTouches(device, numCollections);
+        device->hybridOffset = 0;
+        TouchInputManagerDidProcessReport(gTouchManager, device->locationID);
+        return;
+    }
     
     CFIndex numUpdates = numCollections;
     if (remainingUpdates < numCollections) {
@@ -509,7 +596,17 @@ void DispatchTouches(HIDDeviceState *device) {
     // update the touch data
     for (CFIndex i=0; i<numElementsToPost; i++) {
         IOHIDElementRef collection = (IOHIDElementRef)CFArrayGetValueAtIndex(device->touchCollectionElements, i);
-        DispatchTouchDataForCollection(device, collection);
+        HIDTouchCollectionData data = TouchDataForCollection(device, collection);
+        LogTouchDataForCollection(device, data, i, true, data.contactID);
+        DispatchTouchData(device, data, data.contactID);
+    }
+
+    if (gLogHIDEvents) {
+        for (CFIndex i=numElementsToPost; i<numCollections; i++) {
+            IOHIDElementRef collection = (IOHIDElementRef)CFArrayGetValueAtIndex(device->touchCollectionElements, i);
+            HIDTouchCollectionData data = TouchDataForCollection(device, collection);
+            LogTouchDataForCollection(device, data, i, false, data.contactID);
+        }
     }
     
     device->hybridOffset = device->hybridOffset + numUpdates;
@@ -559,6 +656,11 @@ void SetTouchDevicesSeized(bool seize) {
             ApplySeizeState(&gDevices[i]);
         }
     }
+}
+
+
+void SetHIDEventLogging(bool logEvents) {
+    gLogHIDEvents = logEvents;
 }
 
 
@@ -852,4 +954,3 @@ void CloseHIDManager(void) {
     IOHIDManagerUnscheduleFromRunLoop(gHidManager, gRunLoopRef, kCFRunLoopCommonModes);
     IOHIDManagerClose(gHidManager, kIOHIDOptionsTypeNone);
 }
-

--- a/TouchUpCore/HIDInterpreter.h
+++ b/TouchUpCore/HIDInterpreter.h
@@ -20,4 +20,8 @@ void CloseHIDManager(void);
 /// Applies to currently-connected and future devices. Pen interfaces stay shared.
 void SetTouchDevicesSeized(bool seize);
 
+/// Enables verbose HID report logging. Intended to be wired to the app's
+/// troubleshooting log toggle.
+void SetHIDEventLogging(bool logEvents);
+
 #endif /* HIDInterpreter_h */

--- a/TouchUpCore/TUCCursorUtilities.h
+++ b/TouchUpCore/TUCCursorUtilities.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @property CGFloat doubleClickTolerance;
+@property BOOL logCursorEvents;
 
 - (CGPoint)currentCursorLocation;
 

--- a/TouchUpCore/TUCCursorUtilities.m
+++ b/TouchUpCore/TUCCursorUtilities.m
@@ -56,6 +56,9 @@
 - (void)moveCursorTo:(CGPoint)aLocation {
     [self cancelMomentumScroll];
     [self stopDraggingCursor];
+    if (self.logCursorEvents) {
+        NSLog(@"TouchUp cursor move location=%@", NSStringFromPoint(aLocation));
+    }
     
     CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved, aLocation, kCGMouseButtonLeft);
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, 0);
@@ -87,6 +90,12 @@
  */
 - (void)performClickAt:(CGPoint)aLocation {
     [self updateCursorClickCountWithLocation:aLocation];
+    if (self.logCursorEvents) {
+        NSLog(@"TouchUp cursor click location=%@ clickCount=%ld tolerance=%.2f",
+              NSStringFromPoint(aLocation),
+              (long)self.cursorClickCount,
+              self.doubleClickTolerance);
+    }
     
     CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, aLocation, kCGMouseButtonLeft);
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, self.cursorClickCount);
@@ -109,8 +118,8 @@
         self.cursorClickCount = 1;
     }
     
-    else if ((aLocation.x - self.locationOfLastClick.x) > self.doubleClickTolerance
-             && (aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
+    else if (hypot(aLocation.x - self.locationOfLastClick.x,
+                   aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
         // touch is too far away
         self.cursorClickCount = 1;
     }
@@ -118,6 +127,9 @@
 
 
 - (void)performSecondaryClickAt:(CGPoint)aLocation {
+    if (self.logCursorEvents) {
+        NSLog(@"TouchUp cursor secondaryClick location=%@", NSStringFromPoint(aLocation));
+    }
     CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventRightMouseDown, aLocation, kCGMouseButtonRight);
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, 1);
     CGEventPost(kCGHIDEventTap, event);
@@ -136,6 +148,12 @@
     
     
     if (self.isLeftMouseDown) {
+        if (self.logCursorEvents) {
+            NSLog(@"TouchUp cursor drag location=%@ phase=%lu clickCount=%ld",
+                  NSStringFromPoint(aLocation),
+                  (unsigned long)phase,
+                  (long)self.cursorClickCount);
+        }
         CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDragged, aLocation, kCGMouseButtonLeft);
         CGEventSetIntegerValueField(event, kCGMouseEventClickState, self.cursorClickCount);
         CGEventPost(kCGHIDEventTap, event);
@@ -144,6 +162,13 @@
     } else {
         [self moveCursorTo:aLocation];
         [self updateCursorClickCountWithLocation:aLocation];
+        if (self.logCursorEvents) {
+            NSLog(@"TouchUp cursor dragStart location=%@ phase=%lu clickCount=%ld tolerance=%.2f",
+                  NSStringFromPoint(aLocation),
+                  (unsigned long)phase,
+                  (long)self.cursorClickCount,
+                  self.doubleClickTolerance);
+        }
         CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, aLocation, kCGMouseButtonLeft);
         CGEventSetIntegerValueField(event, kCGMouseEventClickState, self.cursorClickCount);
         CGEventPost(kCGHIDEventTap, event);
@@ -169,6 +194,11 @@
 
 - (void)scroll:(CGPoint)translation phase:(NSTouchPhase)phase {
     [self stopDraggingCursor];
+    if (self.logCursorEvents) {
+        NSLog(@"TouchUp cursor scroll translation=%@ phase=%lu",
+              NSStringFromPoint(translation),
+              (unsigned long)phase);
+    }
     
     CGEventRef event = CGEventCreateScrollWheelEvent2(NULL, kCGScrollEventUnitPixel, 2, translation.y, translation.x, 0);
     

--- a/TouchUpCore/TUCTouchDelegate.h
+++ b/TouchUpCore/TUCTouchDelegate.h
@@ -37,6 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable TUCScreen *)touchscreenForLocationID:(uint32_t)locationID;
 
+@optional
+- (CGPoint)calibratedRelativePoint:(CGPoint)point forLocationID:(uint32_t)locationID;
+
+@required
 /**
  Used to customize which mouse events are posted by the input manager.
  */

--- a/TouchUpCore/TUCTouchInputManager.h
+++ b/TouchUpCore/TUCTouchInputManager.h
@@ -33,6 +33,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property CGFloat doubleClickTolerance;
 
 /**
+ The maximal movement in mm that still lets a Windows-style touch count as a tap.
+ */
+@property CGFloat tapMovementTolerance;
+
+/**
+ In Windows Touch Mode, contacts closer than this threshold are treated as one
+ finger instead of starting a two-finger gesture. Set to 0 to disable.
+ */
+@property CGFloat windowsTouchModeSingleFingerDistance;
+
+/**
  How long the user has to hold before a drag gesture turns into holdAndDrag.
  */
 @property NSTimeInterval holdDuration;
@@ -47,6 +58,21 @@ NS_ASSUME_NONNULL_BEGIN
  If a touchscreen sometimes sends invalid touch data at location (0,0), activate this option to ignore them
  */
 @property BOOL ignoreOriginTouches;
+
+
+/**
+ If enabled, gestures are interpreted closer to a direct Windows-style
+ touchscreen: tap clicks on release, long press secondary-clicks, one-finger
+ movement drags, and two-finger movement scrolls. The default value is NO.
+ */
+@property BOOL usesWindowsTouchMode;
+
+
+/**
+ If enabled, logs touch coordinate conversion, gesture selection, cursor actions,
+ and click counts to the system log. The default value is NO.
+ */
+@property (nonatomic) BOOL logTouchEvents;
 
 
 - (void)start;

--- a/TouchUpCore/TUCTouchInputManager.m
+++ b/TouchUpCore/TUCTouchInputManager.m
@@ -19,16 +19,28 @@
 
 @property BOOL cursorTouchQualifiedForTap; // if the cursor entered moving state once it can no longer be interpreted as tap
 @property BOOL cursorTouchDidHold; //
+@property BOOL cursorTouchDidDrag;
 @property (strong) NSDate *cursorTouchStationarySinceDate;
+@property CGPoint cursorTouchInitialLocation;
+@property BOOL suppressCursorInputUntilAllTouchesEnd;
 
 @property CGFloat pinchDistance;
 
 @property TUCCursorGesture identifiedMultitouchGesture;
 
+- (NSArray<TUCTouch *> *)windowsGestureTouchesFromTouches:(NSArray<TUCTouch *> *)touches cursorTouch:(TUCTouch *)cursorTouch;
+- (CGFloat)distanceInMillimetersBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2 locationID:(uint32_t)locationID;
+
 @end
 
 
 @implementation TUCTouchInputManager
+
+- (void)setLogTouchEvents:(BOOL)logTouchEvents {
+    _logTouchEvents = logTouchEvents;
+    [TUCCursorUtilities sharedInstance].logCursorEvents = logTouchEvents;
+    SetHIDEventLogging(logTouchEvents);
+}
 
 #pragma mark   Start & Stop
 
@@ -103,6 +115,17 @@
 }
 
 
+- (void)clearCursorTouchState {
+    self.cursorTouch = nil;
+    self.gestureAdditionalTouch = nil;
+    self.cursorTouchQualifiedForTap = NO;
+    self.cursorTouchDidHold = NO;
+    self.cursorTouchDidDrag = NO;
+    self.cursorTouchStationarySinceDate = nil;
+    self.suppressCursorInputUntilAllTouchesEnd = NO;
+}
+
+
 
 /**
  Most important event handling callback: it posts the events to the system where the touches need to go
@@ -114,8 +137,29 @@
         return;
     }
     
-    CGPoint point = [self convertDigitizerPointToRelativeScreenPoint:digitizerPoint locationID:locationID];
+    CGPoint convertedPoint = [self convertDigitizerPointToRelativeScreenPoint:digitizerPoint locationID:locationID];
+    CGPoint point = [self calibratedRelativePointForPoint:convertedPoint locationID:locationID];
+    if (self.logTouchEvents) {
+        NSLog(@"TouchUp touch input locationID=0x%08x contact=%ld raw=%@ converted=%@ calibrated=%@ onSurface=%d confidence=%d",
+              locationID,
+              (long)contactID,
+              NSStringFromPoint(digitizerPoint),
+              NSStringFromPoint(convertedPoint),
+              NSStringFromPoint(point),
+              isOnSurface,
+              confidenceFlag);
+    }
     
+    TUCTouch *existingActiveTouch = [self findTouchWithID:contactID locationID:locationID includingPastTouches:NO];
+    if (!isOnSurface && existingActiveTouch == nil) {
+        if (self.logTouchEvents) {
+            NSLog(@"TouchUp ignored stale lift locationID=0x%08x contact=%ld",
+                  locationID,
+                  (long)contactID);
+        }
+        return;
+    }
+
     BOOL isNewTouch = NO;
     TUCTouch *touch = [self obtainTouchWithID:contactID locationID:locationID isNew:&isNewTouch];
     
@@ -123,7 +167,9 @@
         self.cursorTouch = touch;
         self.cursorTouchQualifiedForTap = YES;
         self.cursorTouchDidHold = NO;
+        self.cursorTouchDidDrag = NO;
         self.cursorTouchStationarySinceDate = nil;
+        self.cursorTouchInitialLocation = point;
     }
     
     [touch setLocation: point];
@@ -149,8 +195,23 @@
         
         if (touch.uuid == self.cursorTouch.uuid) {
             if (!isStationary) {
-                self.cursorTouchQualifiedForTap = NO;
-                self.cursorTouchStationarySinceDate = nil;
+                CGFloat tapTravel = [self distanceInMillimetersBetweenRelativePoint:touch.location
+                                                                                and:self.cursorTouchInitialLocation
+                                                                         locationID:locationID];
+                BOOL exceededTapMovementTolerance = tapTravel > self.tapMovementTolerance;
+                if (!self.usesWindowsTouchMode || exceededTapMovementTolerance) {
+                    self.cursorTouchQualifiedForTap = NO;
+                    self.cursorTouchStationarySinceDate = nil;
+                }
+                if (self.usesWindowsTouchMode && exceededTapMovementTolerance) {
+                    self.cursorTouchDidDrag = YES;
+                }
+                if (self.logTouchEvents && self.usesWindowsTouchMode) {
+                    NSLog(@"TouchUp tap candidate travel=%.2fmm threshold=%.2fmm qualified=%d",
+                          tapTravel,
+                          self.tapMovementTolerance,
+                          self.cursorTouchQualifiedForTap);
+                }
                 
             } else if (touch.phase !=  NSTouchPhaseStationary) {
                 self.cursorTouchStationarySinceDate = [NSDate date];
@@ -193,6 +254,10 @@
     
     NSArray<TUCTouch *> *touches = [[self activeTouches] allObjects];
     NSTouchPhase phase = cursorTouch.phase;
+
+    if ([self processWindowsMultitouchForTouches:touches cursorTouch:cursorTouch]) {
+        return;
+    }
     
     
     if (phase == NSTouchPhaseBegan) {
@@ -206,12 +271,17 @@
         if (self.cursorTouchStationarySinceDate != nil) {
             holdDuration = [[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate];
         }
-        if (self.cursorTouchQualifiedForTap && holdDuration > self.holdDuration) {
+        if (self.cursorTouchQualifiedForTap && !self.cursorTouchDidHold && holdDuration > self.holdDuration) {
             // the user left the finger on the screen for the min duration required to produce a hold
             self.cursorTouchDidHold = YES;
+            if (self.usesWindowsTouchMode) {
+                self.cursorTouchQualifiedForTap = NO;
+            }
         }
         
-        [self checkForSecondaryClick];
+        if (!self.usesWindowsTouchMode) {
+            [self checkForSecondaryClick];
+        }
         
         return;
     }
@@ -220,7 +290,11 @@
     else if (phase == NSTouchPhaseEnded) {
         if (self.identifiedMultitouchGesture == _TUCCursorGestureNone ) {
             if (self.cursorTouchDidHold) {
-                [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
+                if (self.usesWindowsTouchMode && !self.cursorTouchDidDrag) {
+                    [self performMouseEventForGesture:TUCCursorGestureLongPress];
+                } else {
+                    [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
+                }
             } else if (!self.cursorTouchQualifiedForTap) {
                 [self performMouseEventForGesture:TUCCursorGestureDrag];
             }
@@ -235,6 +309,8 @@
                 [self performMouseEventForGesture:self.identifiedMultitouchGesture];
             }
         }
+
+        [self clearCursorTouchState];
         
         return;
     }
@@ -242,14 +318,15 @@
     
     else if (phase == NSTouchPhaseCancelled) {
         [self stopCurrentGesture];
+        [self clearCursorTouchState];
         return;
     }
     
-    if ([self checkForSecondaryClick]) {
+    if (!self.usesWindowsTouchMode && [self checkForSecondaryClick]) {
         return;
     }
     
-    if ([touches count] == 2 && [touches containsObject: cursorTouch]) {
+    if (!self.usesWindowsTouchMode && [touches count] == 2 && [touches containsObject: cursorTouch]) {
         // check if we need to initiate two finger drag, pinch, ...
         if (self.identifiedMultitouchGesture == _TUCCursorGestureNone ) {
             
@@ -263,17 +340,14 @@
             if (self.gestureAdditionalTouch.isActive) {
                 CGPoint trajectoryA = [cursorTouch trajectorySign];
                 CGPoint trajectoryB = [otherTouch trajectorySign];
-                
-                
+
+
                 if (   !CGPointEqualToPoint(trajectoryA, CGPointZero)
                     && !CGPointEqualToPoint(trajectoryB, CGPointZero)) {
-                    
+
                     if (!CGPointEqualToPoint(trajectoryA, trajectoryB)) {
                         self.identifiedMultitouchGesture = TUCCursorGesturePinch;
                     }
-                    //                    else {
-                    //                        self.identifiedMultitouchGesture = TUCCursorGestureTwoFingerDrag;
-                    //                    }
                 }
                 
             } else {
@@ -299,10 +373,159 @@
     
     
     if (self.cursorTouchDidHold) {
-        [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
+        if (!self.usesWindowsTouchMode || self.cursorTouchDidDrag) {
+            [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
+        }
+    } else if (self.usesWindowsTouchMode && self.cursorTouchQualifiedForTap) {
+        [self performMouseEventForGesture:TUCCursorGestureTouchDown];
     } else {
         [self performMouseEventForGesture:TUCCursorGestureDrag];
     }
+}
+
+
+- (BOOL)processWindowsMultitouchForTouches:(NSArray<TUCTouch *> *)touches cursorTouch:(TUCTouch *)cursorTouch {
+    if (!self.usesWindowsTouchMode) {
+        return NO;
+    }
+
+    NSArray<TUCTouch *> *gestureTouches = [self windowsGestureTouchesFromTouches:touches cursorTouch:cursorTouch];
+    NSUInteger activeTouchCount = [gestureTouches count];
+    if (activeTouchCount > 1) {
+        self.suppressCursorInputUntilAllTouchesEnd = YES;
+        self.cursorTouchQualifiedForTap = NO;
+        self.cursorTouchDidDrag = YES;
+        [[TUCCursorUtilities sharedInstance] stopDraggingCursor];
+    }
+
+    if (!self.suppressCursorInputUntilAllTouchesEnd) {
+        return NO;
+    }
+
+    if (activeTouchCount == 0) {
+        [self stopCurrentGesture];
+        [self clearCursorTouchState];
+        return YES;
+    }
+
+    if (activeTouchCount != 2 || ![gestureTouches containsObject:cursorTouch]) {
+        [self stopCurrentGesture];
+        return YES;
+    }
+
+    TUCTouch *otherTouch = gestureTouches[1];
+    if (otherTouch.uuid == cursorTouch.uuid) {
+        otherTouch = gestureTouches[0];
+    }
+
+    self.gestureAdditionalTouch = otherTouch;
+
+    BOOL cursorMoved = [self touchMovedInCurrentFrame:cursorTouch];
+    BOOL otherMoved = [self touchMovedInCurrentFrame:otherTouch];
+    BOOL shouldScroll = cursorMoved || otherMoved;
+
+    if (self.logTouchEvents) {
+        NSLog(@"TouchUp windows multitouch active=%lu cursorPhase=%@ otherPhase=%@ cursorMoved=%d otherMoved=%d",
+              (unsigned long)activeTouchCount,
+              [self stringForPhase:cursorTouch.phase],
+              [self stringForPhase:otherTouch.phase],
+              cursorMoved,
+              otherMoved);
+    }
+
+    if (shouldScroll) {
+        self.identifiedMultitouchGesture = TUCCursorGestureTwoFingerDrag;
+        [self performMouseEventForGesture:TUCCursorGestureTwoFingerDrag];
+    }
+
+    return YES;
+}
+
+
+- (NSArray<TUCTouch *> *)windowsGestureTouchesFromTouches:(NSArray<TUCTouch *> *)touches cursorTouch:(TUCTouch *)cursorTouch {
+    if (self.windowsTouchModeSingleFingerDistance <= 0 ||
+        cursorTouch == nil ||
+        ![touches containsObject:cursorTouch]) {
+        return touches;
+    }
+
+    NSMutableArray<TUCTouch *> *gestureTouches = [NSMutableArray arrayWithObject:cursorTouch];
+
+    for (TUCTouch *touch in touches) {
+        if (touch.uuid == cursorTouch.uuid) {
+            continue;
+        }
+
+        if (touch.locationID != cursorTouch.locationID) {
+            [gestureTouches addObject:touch];
+            continue;
+        }
+
+        CGFloat distance = [self distanceInMillimetersBetweenRelativePoint:touch.location
+                                                                       and:cursorTouch.location
+                                                                locationID:cursorTouch.locationID];
+        if (distance < self.windowsTouchModeSingleFingerDistance) {
+            if (self.logTouchEvents) {
+                NSLog(@"TouchUp windows multitouch treating close contact as one finger distance=%.2f threshold=%.2f",
+                      distance,
+                      self.windowsTouchModeSingleFingerDistance);
+            }
+            continue;
+        }
+
+        [gestureTouches addObject:touch];
+    }
+
+    return gestureTouches;
+}
+
+
+- (BOOL)touchMovedInCurrentFrame:(TUCTouch *)touch {
+    if (touch == nil || touch.phase != NSTouchPhaseMoved) {
+        return NO;
+    }
+    NSInteger currentFrameID = [self currentFrameIDForLocationID:touch.locationID];
+    // didProcessReportForLocationID advances the frame before cursor processing.
+    return touch.lastUpdated == currentFrameID || touch.lastUpdated + 1 == currentFrameID;
+}
+
+
+- (CGPoint)screenTranslationForTouch:(TUCTouch *)touch {
+    CGPoint currentLocation = [self convertScreenPointRelativeToAbsolute:touch.location locationID:touch.locationID];
+    CGPoint previousLocation = [self convertScreenPointRelativeToAbsolute:touch.previousLocation locationID:touch.locationID];
+    return CGPointMake(currentLocation.x - previousLocation.x,
+                       currentLocation.y - previousLocation.y);
+}
+
+
+- (CGPoint)scrollTranslationForGesture:(TUCCursorGesture)gesture touch:(TUCTouch *)touch screenLocation:(CGPoint)screenLocation {
+    if (self.usesWindowsTouchMode &&
+        gesture == TUCCursorGestureTwoFingerDrag &&
+        self.gestureAdditionalTouch != nil) {
+        CGPoint translation = CGPointZero;
+        CGFloat contributingTouches = 0;
+        NSArray<TUCTouch *> *scrollTouches = @[touch, self.gestureAdditionalTouch];
+
+        for (TUCTouch *scrollTouch in scrollTouches) {
+            if (![self touchMovedInCurrentFrame:scrollTouch]) {
+                continue;
+            }
+
+            CGPoint touchTranslation = [self screenTranslationForTouch:scrollTouch];
+            translation.x += touchTranslation.x;
+            translation.y += touchTranslation.y;
+            contributingTouches += 1;
+        }
+
+        if (contributingTouches > 0) {
+            return CGPointMake(translation.x / contributingTouches,
+                               translation.y / contributingTouches);
+        }
+    }
+
+    CGPoint previousLocation = [self convertScreenPointRelativeToAbsolute:touch.previousLocation locationID:touch.locationID];
+    return CGPointMake(screenLocation.x - previousLocation.x,
+                       screenLocation.y - previousLocation.y);
 }
 
 
@@ -350,6 +573,17 @@
     
     CGFloat doubleClickSpan = self.doubleClickTolerance * [[self touchscreenForLocationID:touch.locationID] pixelsPerMM];
     [[TUCCursorUtilities sharedInstance] setDoubleClickTolerance:doubleClickSpan];
+
+    if (self.logTouchEvents) {
+        NSLog(@"TouchUp gesture=%@ action=%@ phase=%@ locationID=0x%08x rel=%@ abs=%@ clickZone=%.2f",
+              [self stringForGesture:gesture],
+              [self stringForAction:action],
+              [self stringForPhase:touch.phase],
+              touch.locationID,
+              NSStringFromPoint(touch.location),
+              NSStringFromPoint(screenLocation),
+              doubleClickSpan);
+    }
     
     switch (action) {
         case TUCCursorActionNone:
@@ -387,9 +621,7 @@
             break;
             
         case TUCCursorActionScroll: {
-            CGPoint prevLocation = [self convertScreenPointRelativeToAbsolute:touch.previousLocation locationID:touch.locationID];
-            CGPoint translation = CGPointMake(screenLocation.x - prevLocation.x,
-                                              screenLocation.y - prevLocation.y);
+            CGPoint translation = [self scrollTranslationForGesture:gesture touch:touch screenLocation:screenLocation];
             [utils scroll:translation phase:touch.phase];
             
             break; }
@@ -449,6 +681,14 @@
     CGFloat dy = p1.y - p2.y;
     
     return sqrt( pow(dx, 2) + pow(dy, 2) );
+}
+
+
+- (CGFloat)distanceInMillimetersBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2 locationID:(uint32_t)locationID {
+    TUCScreen *screen = [self touchscreenForLocationID:locationID];
+    CGFloat dx = (p1.x - p2.x) * screen.nativePhysicalSize.width;
+    CGFloat dy = (p1.y - p2.y) * screen.nativePhysicalSize.height;
+    return hypot(dx, dy);
 }
 
 
@@ -567,6 +807,18 @@
     // Then account for any letterboxing when the content doesn't fill the panel (mirroring
     // a differently-shaped display). A no-op when the aspect ratios already match.
     return [screen convertGlassPointToContentPoint:rotated];
+}
+
+
+- (CGPoint)calibratedRelativePointForPoint:(CGPoint)point locationID:(uint32_t)locationID {
+    CGPoint result = point;
+    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(calibratedRelativePoint:forLocationID:)]) {
+        result = [self.delegate calibratedRelativePoint:point forLocationID:locationID];
+    }
+
+    result.x = MAX(0.0, MIN(1.0, result.x));
+    result.y = MAX(0.0, MIN(1.0, result.y));
+    return result;
 }
 
 
@@ -712,10 +964,14 @@
         self.identifiedMultitouchGesture = _TUCCursorGestureNone;
         
         self.doubleClickTolerance = 5;
+        self.tapMovementTolerance = 3;
+        self.windowsTouchModeSingleFingerDistance = 0;
         self.holdDuration = 0.08;
         self.errorResistance = 0;
         
         self.ignoreOriginTouches = NO;
+        self.usesWindowsTouchMode = NO;
+        self.logTouchEvents = NO;
     }
     return self;
 }
@@ -740,6 +996,48 @@
 - (void)triggerSystemAccessibilityAccessAlert {
     CGPoint loc = [[TUCCursorUtilities sharedInstance] currentCursorLocation];
     [[TUCCursorUtilities sharedInstance] moveCursorTo:loc];
+}
+
+
+#pragma mark - Logging
+
+- (NSString *)stringForPhase:(NSTouchPhase)phase {
+    switch (phase) {
+        case NSTouchPhaseBegan: return @"began";
+        case NSTouchPhaseMoved: return @"moved";
+        case NSTouchPhaseStationary: return @"stationary";
+        case NSTouchPhaseEnded: return @"ended";
+        case NSTouchPhaseCancelled: return @"cancelled";
+        default: return [NSString stringWithFormat:@"phase-%lu", (unsigned long)phase];
+    }
+}
+
+- (NSString *)stringForGesture:(TUCCursorGesture)gesture {
+    switch (gesture) {
+        case TUCCursorGestureTouchDown: return @"touchDown";
+        case TUCCursorGestureTap: return @"tap";
+        case TUCCursorGestureLongPress: return @"longPress";
+        case TUCCursorGestureDrag: return @"drag";
+        case TUCCursorGestureHoldAndDrag: return @"holdAndDrag";
+        case TUCCursorGestureTapSecondFinger: return @"tapSecondFinger";
+        case TUCCursorGestureTwoFingerDrag: return @"twoFingerDrag";
+        case TUCCursorGesturePinch: return @"pinch";
+        case _TUCCursorGestureNone: return @"none";
+    }
+}
+
+- (NSString *)stringForAction:(TUCCursorAction)action {
+    switch (action) {
+        case TUCCursorActionNone: return @"none";
+        case TUCCursorActionMove: return @"move";
+        case TUCCursorActionMoveClickIfNeeded: return @"moveClickIfNeeded";
+        case TUCCursorActionPointAndClick: return @"pointAndClick";
+        case TUCCursorActionDrag: return @"drag";
+        case TUCCursorActionClick: return @"click";
+        case TUCCursorActionSecondaryClick: return @"secondaryClick";
+        case TUCCursorActionScroll: return @"scroll";
+        case TUCCursorActionMagnify: return @"magnify";
+    }
 }
 
 


### PR DESCRIPTION
## Windows Touch Mode
- New "Windows Touch Mode" toggle in Settings → Gestures
- Tap-to-click: first tap moves cursor, second tap at same position clicks
- Double-tap produces double-click (via existing cursorClickCount infrastructure)
- Long press triggers secondary click (right-click)
- One-finger drag performs mouse drag instead of scrolling
- Two-finger drag scrolls instead of dragging
- Uses `hypot()` for correct Euclidean double-click distance check (fixes a bug where the original `&&` required both axes to exceed tolerance)

## Per-Digitizer Calibration
- New `TouchCalibration` struct: 6-parameter affine transform (a,b,c,d,e,f)
- Least-squares fitting via 3x3 Gaussian elimination (min 3 sample points)
- 9-point calibration UI in Debug Overlay with real-time error feedback
- Calibration is persisted per-digitizer in `UserDefaults`
- `TUCTouchDelegate` gains optional `-calibratedRelativePoint:forLocationID:`

## HID Event Logging (optional)
- `SetHIDEventLogging()` in HIDInterpreter for troubleshooting
- Structured `os_log_info` output for touch reports
- `logCursorEvents` property on TUCCursorUtilities

## Other
- Rich device identity in `Digitizer` model (name, vendorID, productID, serialNumber)
- Refactored HID non-hybrid touch dispatch into `DispatchNonHybridTouches()`