### PR TITLE
Fix touch mapping on panels that advertise bogus display modes

### DIFF
--- a/TouchUpCore/TUCScreen.m
+++ b/TouchUpCore/TUCScreen.m
@@ -173,6 +173,14 @@
 }
 
 - (CGPoint)convertGlassPointToContentPoint:(CGPoint)glassPoint {
+    // A non-mirrored panel IS its own display: the desktop image fills the glass 1:1, so there
+    // is no letterbox to undo. Only a panel mirroring a differently-shaped master needs aspect
+    // fitting. This also guards against nativeResolution being a bogus max-area advertised mode
+    // (e.g. a generic touch controller reporting 540x1920), which otherwise stretches one axis.
+    if (CGDisplayMirrorsDisplay((CGDirectDisplayID)self.id) == kCGNullDirectDisplay) {
+        return glassPoint;
+    }
+
     CGFloat glassAspect   = self.nativeResolution.width / self.nativeResolution.height;
     CGFloat contentAspect = self.frame.size.width / self.frame.size.height;
     if (glassAspect <= 0 || contentAspect <= 0) {


### PR DESCRIPTION
convertGlassPointToContentPoint derived the touch glass aspect from largestModePixelSizeForDisplayID, which on generic USB touch panels (e.g. a WCH controller advertising a 540x1920 mode) is not the real panel geometry. The aspect mismatch letterbox-stretched one axis, placing taps far from the finger. A non-mirrored panel is its own display and the desktop fills the glass 1:1, so return the point unchanged unless it mirrors a differently-shaped master.


Dude i don't know it didn't work and then claude fixed it. not gonna pretend i understand