### PR TITLE
Fix taps not producing clicks on noisy digitizers (#13)

### DIFF
--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -81,6 +81,10 @@ struct SettingsView: View {
             Slider(value: $model.doubleClickDistance, in: 0...8, step: 1) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.doubleClickDistance))
             }
+
+            Slider(value: $model.tapDistance, in: 0.5...8, step: 0.5) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.tapDistance))
+            }
         }
     }
     

--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -78,7 +78,11 @@ struct SettingsView: View {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.holdDuration))
             }
             
-            Slider(value: $model.doubleClickDistance, in: 0...8, step: 1) {
+            // Range starts at 1: a zero zone can never be satisfied. It reaches well past the
+            // default of 8 because the distance check used to be inert, so this is the first
+            // release where the ceiling actually binds — imprecise taps on a large panel need
+            // the headroom to keep double clicking.
+            Slider(value: $model.doubleClickDistance, in: 1...16, step: 1) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.doubleClickDistance))
             }
 

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -23,6 +23,7 @@ class TouchUp: NSObject, ObservableObject {
     
     @Published var holdDuration: TimeInterval = 0.1
     @Published var doubleClickDistance: CGFloat = 3 //mm
+    @Published var tapDistance: CGFloat = 2.5 //mm
     @Published var errorResistance: NSInteger = 0 // num of Reports to wait before cancelling a touch
     @Published var ignoreOriginTouches: Bool = false
     
@@ -120,6 +121,7 @@ extension TouchUp {
         defaults.register(defaults: [
             "holdDuration" : 0.1,
             "doubleClickDistance" : 8,
+            "tapDistance" : 2.5,
             "errorResistance" : 4,
             "ignoreOriginTouches" : true,
 
@@ -133,6 +135,7 @@ extension TouchUp {
         
         holdDuration = defaults.double(forKey: "holdDuration")
         doubleClickDistance = defaults.double(forKey: "doubleClickDistance")
+        tapDistance = defaults.double(forKey: "tapDistance")
         errorResistance = defaults.integer(forKey: "errorResistance")
         ignoreOriginTouches = defaults.bool(forKey: "ignoreOriginTouches")
 
@@ -141,6 +144,7 @@ extension TouchUp {
             $isPublishingMouseEventsEnabled.assign(to: \.postMouseEvents, on: touchManager),
             $holdDuration.assign(to: \.holdDuration, on: touchManager),
             $doubleClickDistance.assign(to: \.doubleClickTolerance, on: touchManager),
+            $tapDistance.assign(to: \.tapTolerance, on: touchManager),
             $errorResistance.assign(to: \.errorResistance, on: touchManager),
             $ignoreOriginTouches.assign(to: \.ignoreOriginTouches, on: touchManager)
         ]
@@ -161,7 +165,8 @@ extension TouchUp {
         
         defaults.set(holdDuration, forKey: "holdDuration")
         defaults.set(doubleClickDistance, forKey: "doubleClickDistance")
-        defaults.set(errorResistance, forKey: "$errorResistance")
+        defaults.set(tapDistance, forKey: "tapDistance")
+        defaults.set(errorResistance, forKey: "errorResistance")
         defaults.set(ignoreOriginTouches, forKey: "ignoreOriginTouches")
 
         defaults.set(isScrollingWithOneFingerEnabled, forKey: "isScrollingWithOneFingerEnabled")
@@ -398,6 +403,10 @@ extension TouchUp {
         case \.doubleClickDistance:
             return("Double Click Zone",
                    "How many mm can two taps be apart from each other to qualify double click")
+
+        case \.tapDistance:
+            return("Tap Zone",
+                   "How many mm your finger may slide while touching and still count as a tap instead of a drag. Increase this if taps do not click reliably.")
             
         case \.ignoreOriginTouches:
             return("Ignore Origin Touches",

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -134,7 +134,10 @@ extension TouchUp {
         ])
         
         holdDuration = defaults.double(forKey: "holdDuration")
-        doubleClickDistance = defaults.double(forKey: "doubleClickDistance")
+        // A zero zone means two taps can never be close enough to double click. It used to be
+        // selectable while the distance check was broken and therefore inert, so a stored 0 is
+        // not a deliberate choice — lift it to the smallest value the slider now offers.
+        doubleClickDistance = max(1, defaults.double(forKey: "doubleClickDistance"))
         tapDistance = defaults.double(forKey: "tapDistance")
         errorResistance = defaults.integer(forKey: "errorResistance")
         ignoreOriginTouches = defaults.bool(forKey: "ignoreOriginTouches")

--- a/TouchUpCore/TUCCursorUtilities.h
+++ b/TouchUpCore/TUCCursorUtilities.h
@@ -14,6 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 
 
+/**
+ Radius, in screen points, within which a follow-up click continues the current click
+ sequence instead of starting a new one. Callers own the conversion from a physical
+ distance, since points per millimetre differ per screen.
+
+ A non-positive value means no two clicks are ever close enough to form a sequence, i.e. it
+ disables double clicking.
+ */
 @property CGFloat doubleClickTolerance;
 
 - (CGPoint)currentCursorLocation;

--- a/TouchUpCore/TUCCursorUtilities.m
+++ b/TouchUpCore/TUCCursorUtilities.m
@@ -100,17 +100,31 @@
 }
 
 
+/**
+ Advances the click sequence that gets stamped onto the next mouse event as its click state,
+ so that quick repeat taps in the same spot read as a double or triple click.
+
+ A sequence continues only while both conditions hold: the taps follow each other within the
+ system's double-click interval, and the new one lands inside `doubleClickTolerance` of the
+ previous one. Anything else starts a fresh sequence at 1, as does the fourth tap — click
+ state tops out at a triple click.
+ */
 - (void)updateCursorClickCountWithLocation:(CGPoint)aLocation {
     ++self.cursorClickCount;
-    
+
     NSTimeInterval durationSinceLastClick = [[NSDate date] timeIntervalSinceDate:self.timeOfLastClick];
-    
+
     if (durationSinceLastClick > [NSEvent doubleClickInterval] || self.cursorClickCount == 4) {
         self.cursorClickCount = 1;
     }
-    
-    else if ((aLocation.x - self.locationOfLastClick.x) > self.doubleClickTolerance
-             && (aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
+
+    // Distance from the previous click, as a radius. This used to compare the two signed
+    // axis deltas against the tolerance and require *both* to exceed it, which only ever
+    // held for a tap moving down and to the right — so in every other direction two quick
+    // taps anywhere on the glass were promoted to a double click. That is easy to trigger on
+    // a large touchscreen, where consecutive taps are naturally far apart.
+    else if (hypot(aLocation.x - self.locationOfLastClick.x,
+                   aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
         // touch is too far away
         self.cursorClickCount = 1;
     }

--- a/TouchUpCore/TUCScreen.h
+++ b/TouchUpCore/TUCScreen.h
@@ -60,6 +60,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)pixelsPerMM;
 - (CGPoint)convertPointRelativeToAbsolute:(CGPoint)relativePoint;
 
+/// `nativePhysicalSize`, guaranteed to be usable for distance maths. Panels that report no
+/// (or a nonsensical) EDID size fall back to an assumed density, so millimetre thresholds
+/// never collapse to zero or blow up to infinity.
+- (CGSize)effectivePhysicalSize;
+
+/// Physical distance in millimetres between two points given in this screen's relative
+/// content coordinates (each axis normalised to [0,1]). Each axis is scaled by its own
+/// physical extent, so the result stays correct on non-square panels.
+- (CGFloat)millimetreDistanceBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2;
+
 /// Maps a point normalised over the full panel glass (in this screen's orientation) to one
 /// normalised over the letterboxed content rectangle macOS actually draws
 /// The result is clamped to [0,1]; touches on the bars snap to the edge.

--- a/TouchUpCore/TUCScreen.m
+++ b/TouchUpCore/TUCScreen.m
@@ -158,7 +158,33 @@
 - (CGFloat)pixelsPerMM {
     // `frame` and `nativePhysicalSize` are both reported in the same (rotated) on-screen
     // orientation, so their widths line up directly — no manual swap needed.
-    return self.frame.size.width / self.nativePhysicalSize.width;
+    return self.frame.size.width / [self effectivePhysicalSize].width;
+}
+
+- (CGSize)effectivePhysicalSize {
+    CGSize size = self.nativePhysicalSize;
+    if (size.width > 0 && size.height > 0) {
+        return size;
+    }
+
+    // Virtual displays, some capture devices and the occasional panel with a broken EDID
+    // report a zero physical size. Taken literally that turns every millimetre threshold in
+    // the app into either 0 or infinity, so derive a plausible size from the logical frame
+    // instead. `kAssumedPointsPerMM` is ~100 dpi, the usual density of a non-Retina desktop
+    // display — approximate, but in the right order of magnitude, which is all these
+    // thresholds need.
+    static const CGFloat kAssumedPointsPerMM = 4.0;
+    return CGSizeMake(self.frame.size.width / kAssumedPointsPerMM,
+                      self.frame.size.height / kAssumedPointsPerMM);
+}
+
+- (CGFloat)millimetreDistanceBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2 {
+    CGSize physicalSize = [self effectivePhysicalSize];
+
+    CGFloat dx = (p1.x - p2.x) * physicalSize.width;
+    CGFloat dy = (p1.y - p2.y) * physicalSize.height;
+
+    return sqrt(dx * dx + dy * dy);
 }
 
 - (CGPoint)convertPointRelativeToAbsolute:(CGPoint)relativePoint {

--- a/TouchUpCore/TUCTouchInputManager.h
+++ b/TouchUpCore/TUCTouchInputManager.h
@@ -38,6 +38,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSTimeInterval holdDuration;
 
 /**
+ How far (in mm) a finger may travel from where it first touched down and still count as a
+ tap rather than a drag or a scroll.
+
+ Inside this radius a touch produces a click on lift-off and posts no movement events at
+ all. The radius has to be comfortably larger than the digitizer's noise and than the way
+ the reported contact centroid shifts while a finger flattens onto the glass and lifts off
+ again — otherwise those few tenths of a millimetre are read as the start of a drag and the
+ click is never generated.
+ */
+@property CGFloat tapTolerance;
+
+/**
  If a touch is no longer reported by the screen, wait for this number of incoming reports bevore deleting it from the touch set.
  */
 @property NSInteger errorResistance;

--- a/TouchUpCore/TUCTouchInputManager.m
+++ b/TouchUpCore/TUCTouchInputManager.m
@@ -17,8 +17,10 @@
 @property (weak, nullable) TUCTouch *cursorTouch;
 @property (weak, nullable) TUCTouch *gestureAdditionalTouch;
 
-@property BOOL cursorTouchQualifiedForTap; // if the cursor entered moving state once it can no longer be interpreted as tap
+@property CGPoint cursorTouchOrigin; // where the cursor touch first landed, in relative screen coordinates
+@property BOOL cursorTouchQualifiedForTap; // NO once the cursor touch has travelled further than `tapTolerance` from its origin
 @property BOOL cursorTouchDidHold; //
+@property CGPoint cursorTouchStationaryAnchor; // reference point the hold clock is measured against
 @property (strong) NSDate *cursorTouchStationarySinceDate;
 
 @property CGFloat pinchDistance;
@@ -26,6 +28,22 @@
 @property TUCCursorGesture identifiedMultitouchGesture;
 
 @end
+
+
+/**
+ How far (mm) the finger may wander while the hold clock keeps running. Generous enough to
+ absorb digitizer noise and a resting finger's centroid drift, tight enough that a
+ deliberate slow drag keeps resetting the clock instead of turning into a hold.
+ */
+static const CGFloat kHoldStillnessTolerance = 1.0;
+
+/**
+ Per-report movement (mm) below which a touch is reported as `NSTouchPhaseStationary`
+ rather than `NSTouchPhaseMoved`. Deliberately tiny: this only classifies the phase, and a
+ low value keeps slow, fine-grained scrolling responsive. Tap and hold decisions must not
+ use it — they are measured against an anchor point, not the previous report.
+ */
+static const CGFloat kPhaseMovementThreshold = 0.1;
 
 
 @implementation TUCTouchInputManager
@@ -121,9 +139,11 @@
     
     if (isNewTouch && (self.cursorTouch == nil || !self.cursorTouch.isActive)) {
         self.cursorTouch = touch;
+        self.cursorTouchOrigin = point;
         self.cursorTouchQualifiedForTap = YES;
         self.cursorTouchDidHold = NO;
-        self.cursorTouchStationarySinceDate = nil;
+        self.cursorTouchStationaryAnchor = point;
+        self.cursorTouchStationarySinceDate = [NSDate date];
     }
     
     [touch setLocation: point];
@@ -141,23 +161,15 @@
     
     if(touch.previousPhase != NSTouchPhaseEnded && !isNewTouch) {
         // update to an existing touch... check if stationary or not
-        CGFloat digitizerRelDistance = sqrt(pow(touch.location.x - touch.previousLocation.x, 2) + pow(touch.location.y - touch.previousLocation.y, 2));
-        CGFloat screenSize = [self touchscreenForLocationID:locationID].nativePhysicalSize.width;
-        //TODO: - Make customizable in settings?
-        BOOL isStationary = (digitizerRelDistance * screenSize) < 0.1;
-//        BOOL isStationary = CGPointEqualToPoint(touch.location, touch.previousLocation);
-        
+        TUCScreen *screen = [self touchscreenForLocationID:locationID];
+        CGFloat stepDistance = [screen millimetreDistanceBetweenRelativePoint:touch.location
+                                                                          and:touch.previousLocation];
+
         if (touch.uuid == self.cursorTouch.uuid) {
-            if (!isStationary) {
-                self.cursorTouchQualifiedForTap = NO;
-                self.cursorTouchStationarySinceDate = nil;
-                
-            } else if (touch.phase !=  NSTouchPhaseStationary) {
-                self.cursorTouchStationarySinceDate = [NSDate date];
-            }
+            [self updateTapAndHoldStateForCursorTouch:touch onScreen:screen];
         }
-        
-        [touch setPhase:isStationary ? NSTouchPhaseStationary : NSTouchPhaseMoved];
+
+        [touch setPhase:(stepDistance < kPhaseMovementThreshold) ? NSTouchPhaseStationary : NSTouchPhaseMoved];
     }
     
     
@@ -181,6 +193,58 @@
 #pragma mark - Mouse Cursor Management
 
 
+/**
+ Re-evaluates the two movement-dependent decisions about the cursor touch — is it still a
+ tap, and is it still being held in place — after every report.
+
+ Both are measured against an anchor point rather than against the previous report. Doing
+ it per report made them hair-trigger: a few tenths of a millimetre of digitizer noise, or
+ the way the reported contact centroid shifts while a finger flattens onto the glass, was
+ enough to permanently disqualify the tap. On panels noisy enough to cross that line every
+ tap degraded into a drag, so touching an item only moved the cursor there and never
+ clicked it — and hold-and-drag could never arm either.
+ */
+- (void)updateTapAndHoldStateForCursorTouch:(TUCTouch *)touch onScreen:(TUCScreen *)screen {
+
+    // A touch stays a tap until the finger leaves a slop radius around where it landed.
+    // Once it has left, it can never become a tap again.
+    if (self.cursorTouchQualifiedForTap
+        && [screen millimetreDistanceBetweenRelativePoint:touch.location and:self.cursorTouchOrigin] > self.tapTolerance) {
+
+        self.cursorTouchQualifiedForTap = NO;
+        self.cursorTouchStationarySinceDate = nil;
+    }
+
+    // The hold clock runs for as long as the finger stays near its anchor. Wandering off
+    // re-anchors and restarts it, so a slow, deliberate drag never accumulates enough
+    // stillness to be mistaken for a hold.
+    if ([screen millimetreDistanceBetweenRelativePoint:touch.location and:self.cursorTouchStationaryAnchor] > kHoldStillnessTolerance) {
+        self.cursorTouchStationaryAnchor = touch.location;
+
+        if (self.cursorTouchQualifiedForTap) {
+            self.cursorTouchStationarySinceDate = [NSDate date];
+        }
+    }
+}
+
+
+/**
+ Promotes the cursor touch to a hold once it has stayed put for `holdDuration`.
+ Evaluated on every report regardless of phase: on a noisy digitizer the phase flickers
+ between moved and stationary, and a hold must not depend on catching a stationary one.
+ */
+- (void)updateHoldState {
+    if (self.cursorTouchDidHold
+        || !self.cursorTouchQualifiedForTap
+        || self.cursorTouchStationarySinceDate == nil) {
+        return;
+    }
+
+    if ([[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate] > self.holdDuration) {
+        self.cursorTouchDidHold = YES;
+    }
+}
+
 
 - (void)processTouchesForCursorInput {
     
@@ -193,49 +257,42 @@
     
     NSArray<TUCTouch *> *touches = [[self activeTouches] allObjects];
     NSTouchPhase phase = cursorTouch.phase;
-    
-    
+
+    [self updateHoldState];
+
+
     if (phase == NSTouchPhaseBegan) {
         [self performMouseEventForGesture:TUCCursorGestureTouchDown];
         return;
     }
-    
-    
+
+
     else if (phase == NSTouchPhaseStationary) {
-        NSTimeInterval holdDuration = 0;
-        if (self.cursorTouchStationarySinceDate != nil) {
-            holdDuration = [[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate];
-        }
-        if (self.cursorTouchQualifiedForTap && holdDuration > self.holdDuration) {
-            // the user left the finger on the screen for the min duration required to produce a hold
-            self.cursorTouchDidHold = YES;
-        }
-        
         [self checkForSecondaryClick];
-        
+
         return;
     }
-    
-    
+
+
     else if (phase == NSTouchPhaseEnded) {
-        if (self.identifiedMultitouchGesture == _TUCCursorGestureNone ) {
+        // A running multitouch gesture owns the lift-off: `stopCurrentGesture` posts its
+        // terminating event (the final magnify, say) and no click may follow it.
+        BOOL wasMultitouchGesture = self.identifiedMultitouchGesture != _TUCCursorGestureNone;
+
+        if (!wasMultitouchGesture) {
             if (self.cursorTouchDidHold) {
                 [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
             } else if (!self.cursorTouchQualifiedForTap) {
                 [self performMouseEventForGesture:TUCCursorGestureDrag];
             }
         }
-        
+
         [self stopCurrentGesture];
-        
-        if (self.cursorTouchQualifiedForTap) {
+
+        if (!wasMultitouchGesture && self.cursorTouchQualifiedForTap) {
             [self performMouseEventForGesture:TUCCursorGestureTap];
-        } else {
-            if (self.identifiedMultitouchGesture != _TUCCursorGestureNone) {
-                [self performMouseEventForGesture:self.identifiedMultitouchGesture];
-            }
         }
-        
+
         return;
     }
     
@@ -298,6 +355,13 @@
     }
     
     
+    // Still inside the tap slop: the finger has not travelled far enough to mean anything
+    // but a tap yet. Committing to a scroll or a drag here would emit a few pixels of stray
+    // movement on every tap — exactly the noise the slop radius exists to absorb.
+    if (self.cursorTouchQualifiedForTap) {
+        return;
+    }
+
     if (self.cursorTouchDidHold) {
         [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
     } else {
@@ -707,11 +771,12 @@
         
         self.cursorTouchQualifiedForTap = NO;
         self.cursorTouchStationarySinceDate = nil;
-        
+
         self.frameIDsByLocationID = [NSMutableDictionary new];
         self.identifiedMultitouchGesture = _TUCCursorGestureNone;
-        
+
         self.doubleClickTolerance = 5;
+        self.tapTolerance = 2.5;
         self.holdDuration = 0.08;
         self.errorResistance = 0;
         


### PR DESCRIPTION
Fixes #13.

## The bug

A touch only produces a click on lift-off if `cursorTouchQualifiedForTap` is still set when
the finger leaves the glass. That flag was cleared the moment two consecutive HID reports
differed by more than **0.1 mm**:

```objc
CGFloat digitizerRelDistance = sqrt(pow(touch.location.x - touch.previousLocation.x, 2) + ...);
CGFloat screenSize = [self touchscreenForLocationID:locationID].nativePhysicalSize.width;
BOOL isStationary = (digitizerRelDistance * screenSize) < 0.1;
```

0.1 mm is below the reporting resolution of many digitizers, and well below the shift of the
reported contact centroid as a finger flattens onto the glass and lifts off again. On panels
that cross that line, every tap was read as the start of a drag: the cursor moved to the
touch point and no click was ever generated. Hold-and-drag could never arm either, since it
also required the tap flag.

This matches the reports in the issue — including that "On Finger Drag → Point and Click"
works around it, because that mode clicks on `NSTouchPhaseEnded` regardless of the flag (and
costs you one-finger scrolling in exchange).

Whether the threshold trips is a property of the panel, which is why the bug is
screen-specific rather than universal.

## The fix

Measure the tap and hold decisions against an **anchor point** rather than against the
previous report:

- A touch stays a tap until the finger leaves a slop radius around where it landed,
  configurable as **Tap Zone** (default 2.5 mm).
- The hold clock runs while the finger stays within 1 mm of its anchor and restarts when it
  wanders off, so a slow deliberate drag still never turns into a hold. It is now evaluated
  on every report instead of only stationary ones, which a flickering phase used to swallow.
- Scroll and drag no longer start until the tap slop is exceeded, so digitizer noise can't
  leak a few pixels of stray scroll into a tap.

The per-report threshold stays, but only to classify the touch phase, where a small value
keeps fine slow scrolling responsive. Nothing consequential hangs off it anymore.

## Also fixed

Three things in the same code paths, each with its own commit message detail:

- **Distances were anisotropic.** Relative coordinates were scaled by the panel *width* on
  both axes, so every vertical mm threshold was off by the aspect ratio.
  `-[TUCScreen millimetreDistanceBetweenRelativePoint:and:]` scales each axis by its own
  physical extent.
- **Zero EDID physical size.** Panels reporting no physical size turned every mm threshold
  into 0 or infinity — which would have made the tap slop infinite and disabled scrolling
  outright. `-[TUCScreen effectivePhysicalSize]` falls back to an assumed ~100 dpi.
- **`"$errorResistance"` key typo** meant Error Resistance never persisted.
- Dropped a dead branch that re-posted `identifiedMultitouchGesture` after
  `stopCurrentGesture` had already cleared it. `stopMagnifying` already posts the
  terminating magnify, so nothing is lost.

## Second commit: quick taps far apart registering as a double click

Found while tracing the tap path. The distance guard in the click-sequence counter compared
the two **signed** axis deltas and required **both** to exceed the tolerance:

```objc
else if ((aLocation.x - self.locationOfLastClick.x) > self.doubleClickTolerance
         && (aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
```

So a new sequence only started when the second tap landed down *and* to the right of the
first. In every other direction the guard could not fire and the tap inherited click state 2
— meaning any two quick taps anywhere on a large screen became a double click.

Now compared as a radius, which is what the "Double Click Zone" setting already describes.

The counter is shared with the start of a drag, which deliberately inherits an elevated click
state so a drag right after a tap selects by word. That still works — the drag begins inside
the tap slop, well within the zone — while a drag starting far from the last tap now
correctly begins a plain drag instead of a word selection.

Since this is the first release where the tolerance actually binds, the range is adjusted to
match: the slider no longer offers 0 mm (unsatisfiable; a stored 0 from when the setting was
inert is lifted to 1 on load), and the ceiling goes 8 → 16 mm. Until now the guard was
effectively unbounded, so nothing has ever tested how far apart a deliberate double tap lands
on a wall-sized panel — the headroom keeps those devices working. The default stays 8.

## Compatibility

This is a universal driver, so the intent throughout is that no working configuration
changes behavior:

| Gesture | Behavior |
|---|---|
| Plain tap | Exactly one click (was: none, on affected panels) |
| Slow tap held >100 ms | One click, no drag |
| Hold then drag | Mouse-down once past slop, mouse-up on lift, no trailing click |
| Scroll | Starts after 2.5 mm instead of immediately; no jump when the threshold is crossed |
| Move Cursor mode | Unchanged — `TouchDown` already places the cursor before the dead zone |
| Point and Click mode | Unchanged, still exactly one click |
| Pinch / secondary click | Untouched — both sit before the new gate |

Anyone whose screen worked before had a digitizer quiet enough that the old 0.1 mm check was
never tripping, so the new slop radius doesn't change what they see.

## Testing

Builds clean with no new warnings. **I don't have a touchscreen to verify against yet (that's why its a draft right now, will order one soon)**, so the
behavior above is traced through the code rather than measured — worth a check on real
hardware before merging, particularly the double-click zone, which is the easiest to feel by
hand. The debug overlay will show whether taps now stay inside the slop radius.

## Two notes on things I deliberately left out, in case you'd rather they were in scope

- mouseDown and mouseUp firing together on release (AlexvanGiersbergen's comment on the issue). Real, but separate — performClickAt: posts down+up back to back by design, and it isn't what blocks the click here. Press-and-hold UI would need a different event model.
- The cursorClickCount == 4 wraparound and the fact that dragCursorTo: advances the counter without updating the anchors. Both look intentional; I left them alone.