### PR TITLE
Hold a press for the length of a touch, and fix the click sequence counter

### DIFF
--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -81,6 +81,10 @@ struct SettingsView: View {
             Slider(value: $model.doubleClickDistance, in: 0...8, step: 1) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.doubleClickDistance))
             }
+
+            Slider(value: $model.tapDistance, in: 0.5...8, step: 0.5) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.tapDistance))
+            }
         }
     }
     

--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -65,6 +65,10 @@ struct SettingsView: View {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.isMagnificationEnabled))
             }
             
+            Toggle(isOn: $model.isPressAndHoldEnabled) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.isPressAndHoldEnabled))
+            }
+
             Toggle(isOn: $model.isClickWindowToFrontEnabled) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.isClickWindowToFrontEnabled))
             }

--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -78,7 +78,11 @@ struct SettingsView: View {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.holdDuration))
             }
             
-            Slider(value: $model.doubleClickDistance, in: 0...8, step: 1) {
+            // Range starts at 1: a zero zone can never be satisfied. It reaches well past the
+            // default of 8 because the distance check used to be inert, so this is the first
+            // release where the ceiling actually binds — imprecise taps on a large panel need
+            // the headroom to keep double clicking.
+            Slider(value: $model.doubleClickDistance, in: 1...16, step: 1) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.doubleClickDistance))
             }
 

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -32,6 +32,7 @@ class TouchUp: NSObject, ObservableObject {
     @Published var isMagnificationEnabled = false
     @Published var isClickWindowToFrontEnabled = false
     @Published var isClickOnLiftEnabled = false
+    @Published var isPressAndHoldEnabled = false
 
     @Published var areAdditionalDigitizerRotationSettingsVisible = false
 
@@ -130,6 +131,7 @@ extension TouchUp {
             "isMagnificationEnabled" : true,
             "isClickWindowToFrontEnabled" : false,
             "isClickOnLiftEnabled" : false,
+            "isPressAndHoldEnabled" : false,
             "areAdditionalDigitizerRotationSettingsVisible" : false
         ])
         
@@ -159,6 +161,7 @@ extension TouchUp {
         isMagnificationEnabled = defaults.bool(forKey: "isMagnificationEnabled")
         isClickWindowToFrontEnabled = defaults.bool(forKey: "isClickWindowToFrontEnabled")
         isClickOnLiftEnabled = defaults.bool(forKey: "isClickOnLiftEnabled")
+        isPressAndHoldEnabled = defaults.bool(forKey: "isPressAndHoldEnabled")
         areAdditionalDigitizerRotationSettingsVisible = defaults.bool(forKey: "areAdditionalDigitizerRotationSettingsVisible")
     }
     
@@ -177,6 +180,7 @@ extension TouchUp {
         defaults.set(isMagnificationEnabled, forKey: "isMagnificationEnabled")
         defaults.set(isClickWindowToFrontEnabled, forKey: "isClickWindowToFrontEnabled")
         defaults.set(isClickOnLiftEnabled, forKey: "isClickOnLiftEnabled")
+        defaults.set(isPressAndHoldEnabled, forKey: "isPressAndHoldEnabled")
         defaults.set(areAdditionalDigitizerRotationSettingsVisible, forKey: "areAdditionalDigitizerRotationSettingsVisible")
     }
 
@@ -323,8 +327,13 @@ extension TouchUp: TUCTouchDelegate {
             return .click
             
         case .TUCCursorGestureLongPress:
-            return .click
-            
+            // Posted once the resting finger has made the gesture unambiguous. Mapping it to a
+            // drag presses the button there and holds it until lift-off, which is what apps
+            // expecting a real press-and-hold need; the lift-off click is suppressed in that
+            // case so the touch still actuates exactly once. Off by default, because it turns
+            // a long rest into a held button rather than the click it produces today.
+            return isPressAndHoldEnabled ? .drag : .none
+
         case .TUCCursorGestureDrag:
             return isClickOnLiftEnabled ? .pointAndClick : (isScrollingWithOneFingerEnabled ? .scroll : .move)
             
@@ -398,6 +407,10 @@ extension TouchUp {
         case \.isClickOnLiftEnabled:
             return("Point and click",
                    "Very reduced input set for exhibits: Move cursor by dragging, and click by releasing. Overrides scrolling and dragging functionality.")
+
+        case \.isPressAndHoldEnabled:
+            return("Press and Hold",
+                   "Hold the mouse button down for as long as your finger rests on the screen, instead of clicking once you lift it. Needed by apps that react to a button being held. (EXPERIMENTAL)")
             
         case \.holdDuration:
             return("Hold Duration",

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -23,6 +23,7 @@ class TouchUp: NSObject, ObservableObject {
     
     @Published var holdDuration: TimeInterval = 0.1
     @Published var doubleClickDistance: CGFloat = 3 //mm
+    @Published var tapDistance: CGFloat = 2.5 //mm
     @Published var errorResistance: NSInteger = 0 // num of Reports to wait before cancelling a touch
     @Published var ignoreOriginTouches: Bool = false
     
@@ -120,6 +121,7 @@ extension TouchUp {
         defaults.register(defaults: [
             "holdDuration" : 0.1,
             "doubleClickDistance" : 8,
+            "tapDistance" : 2.5,
             "errorResistance" : 4,
             "ignoreOriginTouches" : true,
 
@@ -133,6 +135,7 @@ extension TouchUp {
         
         holdDuration = defaults.double(forKey: "holdDuration")
         doubleClickDistance = defaults.double(forKey: "doubleClickDistance")
+        tapDistance = defaults.double(forKey: "tapDistance")
         errorResistance = defaults.integer(forKey: "errorResistance")
         ignoreOriginTouches = defaults.bool(forKey: "ignoreOriginTouches")
 
@@ -141,6 +144,7 @@ extension TouchUp {
             $isPublishingMouseEventsEnabled.assign(to: \.postMouseEvents, on: touchManager),
             $holdDuration.assign(to: \.holdDuration, on: touchManager),
             $doubleClickDistance.assign(to: \.doubleClickTolerance, on: touchManager),
+            $tapDistance.assign(to: \.tapTolerance, on: touchManager),
             $errorResistance.assign(to: \.errorResistance, on: touchManager),
             $ignoreOriginTouches.assign(to: \.ignoreOriginTouches, on: touchManager)
         ]
@@ -161,7 +165,8 @@ extension TouchUp {
         
         defaults.set(holdDuration, forKey: "holdDuration")
         defaults.set(doubleClickDistance, forKey: "doubleClickDistance")
-        defaults.set(errorResistance, forKey: "$errorResistance")
+        defaults.set(tapDistance, forKey: "tapDistance")
+        defaults.set(errorResistance, forKey: "errorResistance")
         defaults.set(ignoreOriginTouches, forKey: "ignoreOriginTouches")
 
         defaults.set(isScrollingWithOneFingerEnabled, forKey: "isScrollingWithOneFingerEnabled")
@@ -398,6 +403,10 @@ extension TouchUp {
         case \.doubleClickDistance:
             return("Double Click Zone",
                    "How many mm can two taps be apart from each other to qualify double click")
+
+        case \.tapDistance:
+            return("Tap Zone",
+                   "How many mm your finger may slide while touching and still count as a tap instead of a drag. Increase this if taps do not click reliably.")
             
         case \.ignoreOriginTouches:
             return("Ignore Origin Touches",

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -134,7 +134,10 @@ extension TouchUp {
         ])
         
         holdDuration = defaults.double(forKey: "holdDuration")
-        doubleClickDistance = defaults.double(forKey: "doubleClickDistance")
+        // A zero zone means two taps can never be close enough to double click. It used to be
+        // selectable while the distance check was broken and therefore inert, so a stored 0 is
+        // not a deliberate choice — lift it to the smallest value the slider now offers.
+        doubleClickDistance = max(1, defaults.double(forKey: "doubleClickDistance"))
         tapDistance = defaults.double(forKey: "tapDistance")
         errorResistance = defaults.integer(forKey: "errorResistance")
         ignoreOriginTouches = defaults.bool(forKey: "ignoreOriginTouches")

--- a/TouchUpCore/TUCCursorUtilities.h
+++ b/TouchUpCore/TUCCursorUtilities.h
@@ -24,6 +24,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property CGFloat doubleClickTolerance;
 
+/**
+ Whether the left button is currently held down, i.e. a drag is in progress. Callers use this
+ to tell an already-actuated press from an untouched button, so that releasing a held press
+ does not also emit a separate click.
+ */
+@property (readonly) BOOL isLeftMouseDown;
+
 - (CGPoint)currentCursorLocation;
 
 - (void)bringWindowToFrontAt:(CGPoint)aLocation;

--- a/TouchUpCore/TUCCursorUtilities.h
+++ b/TouchUpCore/TUCCursorUtilities.h
@@ -14,6 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 
 
+/**
+ Radius, in screen points, within which a follow-up click continues the current click
+ sequence instead of starting a new one. Callers own the conversion from a physical
+ distance, since points per millimetre differ per screen.
+
+ A non-positive value means no two clicks are ever close enough to form a sequence, i.e. it
+ disables double clicking.
+ */
 @property CGFloat doubleClickTolerance;
 
 - (CGPoint)currentCursorLocation;

--- a/TouchUpCore/TUCCursorUtilities.m
+++ b/TouchUpCore/TUCCursorUtilities.m
@@ -65,6 +65,16 @@
 
 
 
+/**
+ Posts a click whose only job is to raise the window under it, for a tap that landed on a
+ window that is not frontmost.
+
+ Deliberately not built on `performClickAt:`: the click state is pinned to 1 and the click
+ sequence is left untouched, because this click is injected by us rather than performed by
+ the user. Letting it advance the sequence would make the real click that the same tap
+ produces on lift-off arrive as a double click — and would let a preceding double tap leak
+ its own elevated click state into the raise.
+ */
 - (void)bringWindowToFrontAt:(CGPoint)aLocation {
     CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, aLocation, kCGMouseButtonLeft);
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, 1);

--- a/TouchUpCore/TUCCursorUtilities.m
+++ b/TouchUpCore/TUCCursorUtilities.m
@@ -13,7 +13,7 @@
 @property NSDate *timeOfLastClick;
 @property CGPoint locationOfLastClick;
 
-@property BOOL isLeftMouseDown;
+@property (readwrite) BOOL isLeftMouseDown;
 
 @property CGPoint momentumScrollTranslation;
 @property (strong) NSTimer *momentumScrollTimer;
@@ -83,38 +83,56 @@
 }
 
 /**
- integrated double click support: needs checks time between clicks and spatial distance
+ Posts a complete press and release. Integrated double click support: checks time between
+ clicks and spatial distance.
+
+ Both halves are emitted here, at the moment the finger lifts, so a plain tap has no
+ press-and-hold phase for an app to observe. That is not an oversight, and moving the press
+ to touch-down would break one-finger scrolling: while the finger is still on the glass the
+ gesture is genuinely undecided — tap, scroll, pinch and secondary click all start
+ identically — and a press that has already been delivered cannot be taken back, so an app
+ would begin selecting text the moment the user meant to scroll. The press can only be
+ emitted early once the gesture is no longer ambiguous, which is what the hold does; see
+ `TUCCursorGestureLongPress` and `-dragCursorTo:phase:`.
  */
 - (void)performClickAt:(CGPoint)aLocation {
     [self updateCursorClickCountWithLocation:aLocation];
-    
-    CGEventRef event = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, aLocation, kCGMouseButtonLeft);
-    CGEventSetIntegerValueField(event, kCGMouseEventClickState, self.cursorClickCount);
-    CGEventPost(kCGHIDEventTap, event);
-    CGEventSetType(event, kCGEventLeftMouseUp);
-    CGEventPost(kCGHIDEventTap, event);
-    CFRelease(event);
-    
-    self.timeOfLastClick = [NSDate date];
-    self.locationOfLastClick = aLocation;
+
+    // Two purpose-built events rather than one object re-typed and posted twice: that shared
+    // a single creation timestamp between the press and the release, so the pair carried a
+    // press duration of exactly zero.
+    CGEventRef mouseDown = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, aLocation, kCGMouseButtonLeft);
+    CGEventSetIntegerValueField(mouseDown, kCGMouseEventClickState, self.cursorClickCount);
+    CGEventPost(kCGHIDEventTap, mouseDown);
+    CFRelease(mouseDown);
+
+    CGEventRef mouseUp = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, aLocation, kCGMouseButtonLeft);
+    CGEventSetIntegerValueField(mouseUp, kCGMouseEventClickState, self.cursorClickCount);
+    CGEventPost(kCGHIDEventTap, mouseUp);
+    CFRelease(mouseUp);
 }
 
 
 /**
  Advances the click sequence that gets stamped onto the next mouse event as its click state,
- so that quick repeat taps in the same spot read as a double or triple click.
+ so that quick repeat presses in the same spot read as a double or triple click.
 
- A sequence continues only while both conditions hold: the taps follow each other within the
- system's double-click interval, and the new one lands inside `doubleClickTolerance` of the
- previous one. Anything else starts a fresh sequence at 1, as does the fourth tap — click
- state tops out at a triple click.
+ A sequence continues only while both conditions hold: the presses follow each other within
+ the system's double-click interval, and the new one lands inside `doubleClickTolerance` of
+ the previous one. Anything else starts a fresh sequence at 1.
+
+ The count is not capped. A real mouse keeps counting past a triple click — a quadruple click
+ selects a paragraph in some text views — and it used to wrap back to 1 on the fourth press
+ here, which made the *fifth* press of a rapid series look like the second press of a new
+ double click. Rapid repeat tapping therefore produced double clicks the user never asked
+ for.
  */
 - (void)updateCursorClickCountWithLocation:(CGPoint)aLocation {
     ++self.cursorClickCount;
 
     NSTimeInterval durationSinceLastClick = [[NSDate date] timeIntervalSinceDate:self.timeOfLastClick];
 
-    if (durationSinceLastClick > [NSEvent doubleClickInterval] || self.cursorClickCount == 4) {
+    if (durationSinceLastClick > [NSEvent doubleClickInterval]) {
         self.cursorClickCount = 1;
     }
 
@@ -128,6 +146,14 @@
         // touch is too far away
         self.cursorClickCount = 1;
     }
+
+    // Every press that advances the sequence also becomes the reference for the next one.
+    // This used to be done by `performClickAt:` alone, so the press that starts a drag
+    // consumed a count without moving the reference forward: the window for the following
+    // tap was still measured from the click *before* the drag, letting that tap inherit a
+    // count it had not earned — tap, drag, tap at one spot arrived as a triple click.
+    self.timeOfLastClick = [NSDate date];
+    self.locationOfLastClick = aLocation;
 }
 
 

--- a/TouchUpCore/TUCCursorUtilities.m
+++ b/TouchUpCore/TUCCursorUtilities.m
@@ -100,17 +100,31 @@
 }
 
 
+/**
+ Advances the click sequence that gets stamped onto the next mouse event as its click state,
+ so that quick repeat taps in the same spot read as a double or triple click.
+
+ A sequence continues only while both conditions hold: the taps follow each other within the
+ system's double-click interval, and the new one lands inside `doubleClickTolerance` of the
+ previous one. Anything else starts a fresh sequence at 1, as does the fourth tap — click
+ state tops out at a triple click.
+ */
 - (void)updateCursorClickCountWithLocation:(CGPoint)aLocation {
     ++self.cursorClickCount;
-    
+
     NSTimeInterval durationSinceLastClick = [[NSDate date] timeIntervalSinceDate:self.timeOfLastClick];
-    
+
     if (durationSinceLastClick > [NSEvent doubleClickInterval] || self.cursorClickCount == 4) {
         self.cursorClickCount = 1;
     }
-    
-    else if ((aLocation.x - self.locationOfLastClick.x) > self.doubleClickTolerance
-             && (aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
+
+    // Distance from the previous click, as a radius. This used to compare the two signed
+    // axis deltas against the tolerance and require *both* to exceed it, which only ever
+    // held for a tap moving down and to the right — so in every other direction two quick
+    // taps anywhere on the glass were promoted to a double click. That is easy to trigger on
+    // a large touchscreen, where consecutive taps are naturally far apart.
+    else if (hypot(aLocation.x - self.locationOfLastClick.x,
+                   aLocation.y - self.locationOfLastClick.y) > self.doubleClickTolerance) {
         // touch is too far away
         self.cursorClickCount = 1;
     }

--- a/TouchUpCore/TUCScreen.h
+++ b/TouchUpCore/TUCScreen.h
@@ -60,6 +60,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)pixelsPerMM;
 - (CGPoint)convertPointRelativeToAbsolute:(CGPoint)relativePoint;
 
+/// `nativePhysicalSize`, guaranteed to be usable for distance maths. Panels that report no
+/// (or a nonsensical) EDID size fall back to an assumed density, so millimetre thresholds
+/// never collapse to zero or blow up to infinity.
+- (CGSize)effectivePhysicalSize;
+
+/// Physical distance in millimetres between two points given in this screen's relative
+/// content coordinates (each axis normalised to [0,1]). Each axis is scaled by its own
+/// physical extent, so the result stays correct on non-square panels.
+- (CGFloat)millimetreDistanceBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2;
+
 /// Maps a point normalised over the full panel glass (in this screen's orientation) to one
 /// normalised over the letterboxed content rectangle macOS actually draws
 /// The result is clamped to [0,1]; touches on the bars snap to the edge.

--- a/TouchUpCore/TUCScreen.m
+++ b/TouchUpCore/TUCScreen.m
@@ -158,7 +158,33 @@
 - (CGFloat)pixelsPerMM {
     // `frame` and `nativePhysicalSize` are both reported in the same (rotated) on-screen
     // orientation, so their widths line up directly — no manual swap needed.
-    return self.frame.size.width / self.nativePhysicalSize.width;
+    return self.frame.size.width / [self effectivePhysicalSize].width;
+}
+
+- (CGSize)effectivePhysicalSize {
+    CGSize size = self.nativePhysicalSize;
+    if (size.width > 0 && size.height > 0) {
+        return size;
+    }
+
+    // Virtual displays, some capture devices and the occasional panel with a broken EDID
+    // report a zero physical size. Taken literally that turns every millimetre threshold in
+    // the app into either 0 or infinity, so derive a plausible size from the logical frame
+    // instead. `kAssumedPointsPerMM` is ~100 dpi, the usual density of a non-Retina desktop
+    // display — approximate, but in the right order of magnitude, which is all these
+    // thresholds need.
+    static const CGFloat kAssumedPointsPerMM = 4.0;
+    return CGSizeMake(self.frame.size.width / kAssumedPointsPerMM,
+                      self.frame.size.height / kAssumedPointsPerMM);
+}
+
+- (CGFloat)millimetreDistanceBetweenRelativePoint:(CGPoint)p1 and:(CGPoint)p2 {
+    CGSize physicalSize = [self effectivePhysicalSize];
+
+    CGFloat dx = (p1.x - p2.x) * physicalSize.width;
+    CGFloat dy = (p1.y - p2.y) * physicalSize.height;
+
+    return sqrt(dx * dx + dy * dy);
 }
 
 - (CGPoint)convertPointRelativeToAbsolute:(CGPoint)relativePoint {

--- a/TouchUpCore/TUCTouchInputManager.h
+++ b/TouchUpCore/TUCTouchInputManager.h
@@ -38,6 +38,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSTimeInterval holdDuration;
 
 /**
+ How far (in mm) a finger may travel from where it first touched down and still count as a
+ tap rather than a drag or a scroll.
+
+ Inside this radius a touch produces a click on lift-off and posts no movement events at
+ all. The radius has to be comfortably larger than the digitizer's noise and than the way
+ the reported contact centroid shifts while a finger flattens onto the glass and lifts off
+ again — otherwise those few tenths of a millimetre are read as the start of a drag and the
+ click is never generated.
+ */
+@property CGFloat tapTolerance;
+
+/**
  If a touch is no longer reported by the screen, wait for this number of incoming reports bevore deleting it from the touch set.
  */
 @property NSInteger errorResistance;

--- a/TouchUpCore/TUCTouchInputManager.m
+++ b/TouchUpCore/TUCTouchInputManager.m
@@ -17,8 +17,10 @@
 @property (weak, nullable) TUCTouch *cursorTouch;
 @property (weak, nullable) TUCTouch *gestureAdditionalTouch;
 
-@property BOOL cursorTouchQualifiedForTap; // if the cursor entered moving state once it can no longer be interpreted as tap
+@property CGPoint cursorTouchOrigin; // where the cursor touch first landed, in relative screen coordinates
+@property BOOL cursorTouchQualifiedForTap; // NO once the cursor touch has travelled further than `tapTolerance` from its origin
 @property BOOL cursorTouchDidHold; //
+@property CGPoint cursorTouchStationaryAnchor; // reference point the hold clock is measured against
 @property (strong) NSDate *cursorTouchStationarySinceDate;
 
 @property CGFloat pinchDistance;
@@ -26,6 +28,22 @@
 @property TUCCursorGesture identifiedMultitouchGesture;
 
 @end
+
+
+/**
+ How far (mm) the finger may wander while the hold clock keeps running. Generous enough to
+ absorb digitizer noise and a resting finger's centroid drift, tight enough that a
+ deliberate slow drag keeps resetting the clock instead of turning into a hold.
+ */
+static const CGFloat kHoldStillnessTolerance = 1.0;
+
+/**
+ Per-report movement (mm) below which a touch is reported as `NSTouchPhaseStationary`
+ rather than `NSTouchPhaseMoved`. Deliberately tiny: this only classifies the phase, and a
+ low value keeps slow, fine-grained scrolling responsive. Tap and hold decisions must not
+ use it — they are measured against an anchor point, not the previous report.
+ */
+static const CGFloat kPhaseMovementThreshold = 0.1;
 
 
 @implementation TUCTouchInputManager
@@ -121,9 +139,11 @@
     
     if (isNewTouch && (self.cursorTouch == nil || !self.cursorTouch.isActive)) {
         self.cursorTouch = touch;
+        self.cursorTouchOrigin = point;
         self.cursorTouchQualifiedForTap = YES;
         self.cursorTouchDidHold = NO;
-        self.cursorTouchStationarySinceDate = nil;
+        self.cursorTouchStationaryAnchor = point;
+        self.cursorTouchStationarySinceDate = [NSDate date];
     }
     
     [touch setLocation: point];
@@ -141,23 +161,15 @@
     
     if(touch.previousPhase != NSTouchPhaseEnded && !isNewTouch) {
         // update to an existing touch... check if stationary or not
-        CGFloat digitizerRelDistance = sqrt(pow(touch.location.x - touch.previousLocation.x, 2) + pow(touch.location.y - touch.previousLocation.y, 2));
-        CGFloat screenSize = [self touchscreenForLocationID:locationID].nativePhysicalSize.width;
-        //TODO: - Make customizable in settings?
-        BOOL isStationary = (digitizerRelDistance * screenSize) < 0.1;
-//        BOOL isStationary = CGPointEqualToPoint(touch.location, touch.previousLocation);
-        
+        TUCScreen *screen = [self touchscreenForLocationID:locationID];
+        CGFloat stepDistance = [screen millimetreDistanceBetweenRelativePoint:touch.location
+                                                                          and:touch.previousLocation];
+
         if (touch.uuid == self.cursorTouch.uuid) {
-            if (!isStationary) {
-                self.cursorTouchQualifiedForTap = NO;
-                self.cursorTouchStationarySinceDate = nil;
-                
-            } else if (touch.phase !=  NSTouchPhaseStationary) {
-                self.cursorTouchStationarySinceDate = [NSDate date];
-            }
+            [self updateTapAndHoldStateForCursorTouch:touch onScreen:screen];
         }
-        
-        [touch setPhase:isStationary ? NSTouchPhaseStationary : NSTouchPhaseMoved];
+
+        [touch setPhase:(stepDistance < kPhaseMovementThreshold) ? NSTouchPhaseStationary : NSTouchPhaseMoved];
     }
     
     
@@ -181,6 +193,58 @@
 #pragma mark - Mouse Cursor Management
 
 
+/**
+ Re-evaluates the two movement-dependent decisions about the cursor touch — is it still a
+ tap, and is it still being held in place — after every report.
+
+ Both are measured against an anchor point rather than against the previous report. Doing
+ it per report made them hair-trigger: a few tenths of a millimetre of digitizer noise, or
+ the way the reported contact centroid shifts while a finger flattens onto the glass, was
+ enough to permanently disqualify the tap. On panels noisy enough to cross that line every
+ tap degraded into a drag, so touching an item only moved the cursor there and never
+ clicked it — and hold-and-drag could never arm either.
+ */
+- (void)updateTapAndHoldStateForCursorTouch:(TUCTouch *)touch onScreen:(TUCScreen *)screen {
+
+    // A touch stays a tap until the finger leaves a slop radius around where it landed.
+    // Once it has left, it can never become a tap again.
+    if (self.cursorTouchQualifiedForTap
+        && [screen millimetreDistanceBetweenRelativePoint:touch.location and:self.cursorTouchOrigin] > self.tapTolerance) {
+
+        self.cursorTouchQualifiedForTap = NO;
+        self.cursorTouchStationarySinceDate = nil;
+    }
+
+    // The hold clock runs for as long as the finger stays near its anchor. Wandering off
+    // re-anchors and restarts it, so a slow, deliberate drag never accumulates enough
+    // stillness to be mistaken for a hold.
+    if ([screen millimetreDistanceBetweenRelativePoint:touch.location and:self.cursorTouchStationaryAnchor] > kHoldStillnessTolerance) {
+        self.cursorTouchStationaryAnchor = touch.location;
+
+        if (self.cursorTouchQualifiedForTap) {
+            self.cursorTouchStationarySinceDate = [NSDate date];
+        }
+    }
+}
+
+
+/**
+ Promotes the cursor touch to a hold once it has stayed put for `holdDuration`.
+ Evaluated on every report regardless of phase: on a noisy digitizer the phase flickers
+ between moved and stationary, and a hold must not depend on catching a stationary one.
+ */
+- (void)updateHoldState {
+    if (self.cursorTouchDidHold
+        || !self.cursorTouchQualifiedForTap
+        || self.cursorTouchStationarySinceDate == nil) {
+        return;
+    }
+
+    if ([[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate] > self.holdDuration) {
+        self.cursorTouchDidHold = YES;
+    }
+}
+
 
 - (void)processTouchesForCursorInput {
     
@@ -193,49 +257,42 @@
     
     NSArray<TUCTouch *> *touches = [[self activeTouches] allObjects];
     NSTouchPhase phase = cursorTouch.phase;
-    
-    
+
+    [self updateHoldState];
+
+
     if (phase == NSTouchPhaseBegan) {
         [self performMouseEventForGesture:TUCCursorGestureTouchDown];
         return;
     }
-    
-    
+
+
     else if (phase == NSTouchPhaseStationary) {
-        NSTimeInterval holdDuration = 0;
-        if (self.cursorTouchStationarySinceDate != nil) {
-            holdDuration = [[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate];
-        }
-        if (self.cursorTouchQualifiedForTap && holdDuration > self.holdDuration) {
-            // the user left the finger on the screen for the min duration required to produce a hold
-            self.cursorTouchDidHold = YES;
-        }
-        
         [self checkForSecondaryClick];
-        
+
         return;
     }
-    
-    
+
+
     else if (phase == NSTouchPhaseEnded) {
-        if (self.identifiedMultitouchGesture == _TUCCursorGestureNone ) {
+        // A running multitouch gesture owns the lift-off: `stopCurrentGesture` posts its
+        // terminating event (the final magnify, say) and no click may follow it.
+        BOOL wasMultitouchGesture = self.identifiedMultitouchGesture != _TUCCursorGestureNone;
+
+        if (!wasMultitouchGesture) {
             if (self.cursorTouchDidHold) {
                 [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
             } else if (!self.cursorTouchQualifiedForTap) {
                 [self performMouseEventForGesture:TUCCursorGestureDrag];
             }
         }
-        
+
         [self stopCurrentGesture];
-        
-        if (self.cursorTouchQualifiedForTap) {
+
+        if (!wasMultitouchGesture && self.cursorTouchQualifiedForTap) {
             [self performMouseEventForGesture:TUCCursorGestureTap];
-        } else {
-            if (self.identifiedMultitouchGesture != _TUCCursorGestureNone) {
-                [self performMouseEventForGesture:self.identifiedMultitouchGesture];
-            }
         }
-        
+
         return;
     }
     
@@ -298,6 +355,13 @@
     }
     
     
+    // Still inside the tap slop: the finger has not travelled far enough to mean anything
+    // but a tap yet. Committing to a scroll or a drag here would emit a few pixels of stray
+    // movement on every tap — exactly the noise the slop radius exists to absorb.
+    if (self.cursorTouchQualifiedForTap) {
+        return;
+    }
+
     if (self.cursorTouchDidHold) {
         [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
     } else {
@@ -707,11 +771,12 @@
         
         self.cursorTouchQualifiedForTap = NO;
         self.cursorTouchStationarySinceDate = nil;
-        
+
         self.frameIDsByLocationID = [NSMutableDictionary new];
         self.identifiedMultitouchGesture = _TUCCursorGestureNone;
-        
+
         self.doubleClickTolerance = 5;
+        self.tapTolerance = 2.5;
         self.holdDuration = 0.08;
         self.errorResistance = 0;
         

--- a/TouchUpCore/TUCTouchInputManager.m
+++ b/TouchUpCore/TUCTouchInputManager.m
@@ -446,9 +446,12 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
         case TUCCursorActionMoveClickIfNeeded:
             [utils moveCursorTo:screenLocation];
             if ([self isLocationOutsideFrontmostWindow:screenLocation locationID:touch.locationID]) {
-                [utils performClickAt:screenLocation];
+                // Not `performClickAt:`. This click is ours, not the user's: it exists only to
+                // raise the window, and it must stay outside the click sequence so that the
+                // real click the same tap produces on lift-off is still counted as the first.
+                [utils bringWindowToFrontAt:screenLocation];
             }
-            
+
             break;
             
         case TUCCursorActionPointAndClick:
@@ -766,6 +769,13 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
             // our injected raise-click plus the tap's own click would register as a
             // title-bar double-click (→ zoom/fullscreen). A single tap already raises the
             // window, so skip the extra click within the title-bar strip.
+            //
+            // The raise-click no longer seeds a double click — it goes through
+            // `-bringWindowToFrontAt:`, which stays out of the click sequence — so this strip
+            // should now be redundant and could be dropped to make taps on a background
+            // title bar raise the window again. It is kept until that is confirmed on real
+            // hardware, because the failure it guards against (a window unexpectedly zooming
+            // to fullscreen) is destructive and not worth risking on reasoning alone.
             //
             // CGWindowList can't tell us the actual title-bar/toolbar height, so this is a
             // heuristic constant. Erring high (toolbars on Tahoe are tall) costs at most a

--- a/TouchUpCore/TUCTouchInputManager.m
+++ b/TouchUpCore/TUCTouchInputManager.m
@@ -77,6 +77,13 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
 }
 
 - (void)didDisconnectTouchscreenWithLocationID:(uint32_t)locationID {
+    // A touch in progress on this digitizer will never get its lift-off report, and stale
+    // touches are only reaped as further reports come in — which they now never will. Release
+    // whatever it was holding here, or the button stays down for good.
+    if (self.cursorTouch != nil && self.cursorTouch.locationID == locationID) {
+        [self stopCurrentGesture];
+    }
+
     [self.frameIDsByLocationID removeObjectForKey:@(locationID)];
     [self.delegate touchscreenDidDisconnectWithLocationID:locationID];
 }
@@ -232,6 +239,13 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
  Promotes the cursor touch to a hold once it has stayed put for `holdDuration`.
  Evaluated on every report regardless of phase: on a noisy digitizer the phase flickers
  between moved and stationary, and a hold must not depend on catching a stationary one.
+
+ This is also the first moment in a touch at which the gesture is no longer ambiguous — a
+ scroll or a pinch would have moved by now — and therefore the earliest point at which the
+ button may safely be pressed while the finger is still down. `TUCCursorGestureLongPress` is
+ posted exactly once here to offer that; whether it actuates anything is up to the delegate's
+ mapping, since holding the button for the length of the touch is a different interaction
+ model from clicking on lift-off.
  */
 - (void)updateHoldState {
     if (self.cursorTouchDidHold
@@ -242,6 +256,7 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
 
     if ([[NSDate date] timeIntervalSinceDate:self.cursorTouchStationarySinceDate] > self.holdDuration) {
         self.cursorTouchDidHold = YES;
+        [self performMouseEventForGesture:TUCCursorGestureLongPress];
     }
 }
 
@@ -279,6 +294,11 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
         // terminating event (the final magnify, say) and no click may follow it.
         BOOL wasMultitouchGesture = self.identifiedMultitouchGesture != _TUCCursorGestureNone;
 
+        // Read before anything below releases the button. If the press was already actuated
+        // while the finger rested — a hold mapped to a drag — then the lift is that press's
+        // release, and adding a click on top would actuate the same touch twice.
+        BOOL didActuatePress = [[TUCCursorUtilities sharedInstance] isLeftMouseDown];
+
         if (!wasMultitouchGesture) {
             if (self.cursorTouchDidHold) {
                 [self performMouseEventForGesture:TUCCursorGestureHoldAndDrag];
@@ -289,7 +309,7 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
 
         [self stopCurrentGesture];
 
-        if (!wasMultitouchGesture && self.cursorTouchQualifiedForTap) {
+        if (!wasMultitouchGesture && self.cursorTouchQualifiedForTap && !didActuatePress) {
             [self performMouseEventForGesture:TUCCursorGestureTap];
         }
 
@@ -480,7 +500,10 @@ static const CGFloat kPhaseMovementThreshold = 0.1;
     switch(gesture) {
         case TUCCursorGestureTouchDown:         return TUCCursorActionMoveClickIfNeeded;
         case TUCCursorGestureTap:               return TUCCursorActionClick;
-        case TUCCursorGestureLongPress:         return TUCCursorActionClick;
+        // Nothing by default: the lift-off already produces the click, and pressing here too
+        // would actuate the touch twice. Map it to a drag to hold the button for as long as
+        // the finger rests instead.
+        case TUCCursorGestureLongPress:         return TUCCursorActionNone;
         case TUCCursorGestureDrag:              return TUCCursorActionScroll;
         case TUCCursorGestureHoldAndDrag:       return TUCCursorActionDrag;
         case TUCCursorGestureTapSecondFinger:   return TUCCursorActionSecondaryClick;


### PR DESCRIPTION
⚠️ Base this on fix/tap-slop-click-detection, not main. It builds on that branch's tap-slop work — the safe moment to emit an early press only exists because of it. If that PR merges first, retarget to main.

Three follow-ups to the tap-slop PR, all in the click bookkeeping. Stacked on top of it —
please review that one first.

## Relationship to #23 (please read before merging either)

#23 independently found and fixed one of these bugs, and the two changes collide. Worth
settling merge order first.

**Overlap.** The Euclidean double-click fix (`hypot` instead of comparing two signed axis
deltas with `&&`) is in both. @Jac0b-Shi got there independently — same diagnosis, same fix.
It sits in this PR's *base* branch rather than here, so one of the two should drop it,
whichever lands second.

**Conflicts.** A test merge against #23 conflicts in four files:

```
Touch Up/SettingsView.swift
Touch Up/TouchUp.swift
TouchUpCore/TUCCursorUtilities.m
TouchUpCore/TUCTouchInputManager.m
```

The same four conflict from the base branch alone, so this is one overlap across the whole
stack rather than something introduced here. This PR deepens it: #23 adds `logCursorEvents`
logging inside `performClickAt:`, which this PR rewrites, and both edit
`updateCursorClickCountWithLocation:` and the tail of `processTouchesForCursorInput`.

**Not just textual.** #23 adds `cursorTouchInitialLocation` + `tapMovementTolerance` —
origin-based tap slop, the same mechanism as the base branch — but gated behind
`usesWindowsTouchMode`:

```objc
if (!self.usesWindowsTouchMode || exceededTapMovementTolerance) {
    self.cursorTouchQualifiedForTap = NO;
    self.cursorTouchStationarySinceDate = nil;
}
```

With the mode off (the default) `!usesWindowsTouchMode` is true and the flag is cleared on any
non-stationary report, exactly as before — so #23 leaves #13 unfixed for anyone who doesn't
opt into a mode that also changes first-tap-moves/second-tap-clicks, long-press → right-click,
and one-finger-drag → drag. Once tap slop exists unconditionally, that machinery is largely
redundant and Windows Touch Mode can be built on `tapTolerance` instead of carrying its own.
Whoever merges second should reconcile rather than resolve markers.

One more thing worth folding in from #23 either way: its
`distanceInMillimetersBetweenRelativePoint:and:locationID:` reads `nativePhysicalSize`
unguarded, so on a panel reporting no EDID size it returns 0 and the tolerance becomes
effectively infinite. The base branch's `effectivePhysicalSize` covers that.

## Press and hold

A tap emits its mouse-down and mouse-up together at lift-off, so no app ever observes the
button being held. This came up in #13, where it was floated as a possible cause:

> mouseUp and mouseDown both instantaneously fire upon releasing a touch, rather than
> mouseDown firing the moment a touch is detected

That's an accurate description, and it isn't the cause of #13 — but it is a real limitation,
and the reason behind it is worth stating because it constrains any fix. While the finger is
on the glass the gesture is genuinely undecided: tap, scroll, pinch and secondary click all
begin identically. A delivered press cannot be withdrawn, so pressing at touch-down would
start a text selection every single time the user meant to scroll. There is no eager press
that is safe in general.

There *is* a safe moment, and the tap-slop work created it: by the time a hold is recognised,
a scroll or a pinch would already have moved. So `TUCCursorGestureLongPress` — defined in the
enum since the beginning and never once posted — is now emitted there, exactly once per
touch. Mapping it to a drag presses the button at that point and holds it until lift-off,
which is what apps reacting to a held button need. The lift-off click is then suppressed,
keyed off the button already being down, so a touch still actuates exactly once.

Exposed as **"Press and Hold"** in Settings → Gestures, **off by default**. It converts a
long rest into a held button rather than the click it produces today, and that should be a
deliberate choice rather than something users discover by accident. With it off the gesture
maps to `.none` and nothing about current behaviour changes.

Releasing the button on digitizer disconnect goes with it. Stale touches are only reaped as
further reports arrive, so a device unplugged mid-touch left the button down forever. That
was already reachable during a drag; it becomes more reachable once any resting finger can
hold the button, so `didDisconnectTouchscreenWithLocationID:` now stops the gesture.

## Click sequence counter

Two defects, both making the sequence advance where it should have restarted.

**The count wrapped from 4 back to 1.** So the fifth press of a rapid series looked like the
second press of a new double click, and repeated tapping produced double clicks nobody asked
for. A real mouse keeps counting past three — a quadruple click selects a paragraph in some
text views — so the cap is simply gone rather than moved.

**Only `performClickAt:` moved the reference time and location forward.** The press that
starts a drag advanced the count without moving them, so the window for the next tap was
still measured from the click *before* the drag, letting that tap inherit a count it had not
earned — tap, drag, tap in one spot arrived as a triple click. The update now lives in
`updateCursorClickCountWithLocation:`, next to the decision it serves, so every emitted press
becomes the reference for the next one.

That second fix turned out to be a prerequisite rather than a nicety: press-and-hold never
calls `performClickAt:`, so without it the reference would never advance and a double tap
could never form at all.

## The raise-click was a click too

With **Bring Windows to Front** enabled, a tap on a window that isn't frontmost produced
*two* full clicks: `TUCCursorActionMoveClickIfNeeded` injected one to raise the window, and
the same tap's lift-off produced the real one. Both went through `performClickAt:`, so the
injected click advanced the sequence and the real one landed at the same spot, inside the
double-click interval, as click state 2. **Every tap on a background window was a double
click** — in Finder, that opens the item the user meant to select.

It leaked the other way as well: because the raise reused the user's live click count, a tap
shortly after a double tap raised the window with click state 2 or 3.

`bringWindowToFrontAt:` already existed for precisely this job — click state pinned to 1, the
click sequence left alone — and had never been called from anywhere. Wiring it up is the
entire fix.

The title-bar strip in `isLocationOutsideFrontmostWindow` exists only as a workaround for this
bug (its comment says so), and in principle becomes redundant. I've left it in with a comment
recording that, rather than deleting it: the case it guards is a window zooming to fullscreen,
which is destructive enough that it deserves a real-hardware check before the guard goes.
Removing it would restore raise-on-tap for background title bars.

## Also

`performClickAt:` built its event pair by re-typing and re-posting a single event object,
which gave the press and the release one shared creation timestamp and therefore a press
duration of exactly zero. It now creates both events. I can't attribute a specific app
failure to this, so treat it as making the injected click well-formed rather than as a fix
for anything observed.

## Compatibility

| Configuration | Behavior |
|---|---|
| **Press and Hold off (default)** | `LongPress` maps to `.none`; unchanged in every respect |
| Press and Hold on, tap shorter than Hold Duration | One click on lift, as before |
| Press and Hold on, tap longer than Hold Duration | Button down at recognition, up on lift — one actuation, no extra click |
| Press and Hold on, rest then drag | Same drag as today, just pressed earlier |
| Press and Hold on, double tap | Click states 1 then 2 — works because of the reference fix above |
| Bring Windows to Front on, tap on background window | Window raises, then one single click (was: double click) |
| Bring Windows to Front on, genuine double tap | Second tap needs no raise, so it still doubles correctly |
| Bring Windows to Front off (default) | Untouched — the raise path never runs |
| Device unplugged mid-touch | Button released instead of stuck down (improvement, applies either way) |
| Touch cancelled / stale | Already released via `stopCurrentGesture`; unchanged |

Word-selection drag (a drag inheriting click state 2 right after a tap) still works — that
behavior is the reason `dragCursorTo:` advances the counter at all, and it's preserved
deliberately.

## Testing

Builds clean, no new warnings. **No touchscreen here**, so all of the above is traced through
the code rather than measured. Two things want real-device confirmation: Press and Hold,
which is why it ships off by default, and whether the title-bar strip can now be deleted.