### PR TITLE
Ignore touch collections that carry no coordinate data

### DIFF
--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -482,7 +482,7 @@ void DispatchTouchDataForCollection(HIDDeviceState *device, IOHIDElementRef coll
             } // kHIDPage_Digitizer
         }
     }
-    // Koordinat verisi hiç gelmemiş koleksiyon = hayalet temas
+    
         if (x < 0 || y < 0) {
             return;
         }
@@ -513,7 +513,7 @@ void DispatchTouches(HIDDeviceState *device) {
     // update the touch data
     for (CFIndex i=0; i<numElementsToPost; i++) {
         IOHIDElementRef collection = (IOHIDElementRef)CFArrayGetValueAtIndex(device->touchCollectionElements, i);
-        // Koordinat verisi hiç gelmemiş koleksiyon = hayalet temas
+        
         DispatchTouchDataForCollection(device, collection);
     }
     

--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -482,6 +482,10 @@ void DispatchTouchDataForCollection(HIDDeviceState *device, IOHIDElementRef coll
             } // kHIDPage_Digitizer
         }
     }
+    // Koordinat verisi hiç gelmemiş koleksiyon = hayalet temas
+        if (x < 0 || y < 0) {
+            return;
+        }
     TouchInputManagerUpdateTouchPosition(gTouchManager, device->locationID, contactID, x, y, (int)tipSwitch, (int)isValid);
     
     //    if (width != kCFNotFound && height != kCFNotFound && azimuth != kCFNotFound) {
@@ -509,6 +513,7 @@ void DispatchTouches(HIDDeviceState *device) {
     // update the touch data
     for (CFIndex i=0; i<numElementsToPost; i++) {
         IOHIDElementRef collection = (IOHIDElementRef)CFArrayGetValueAtIndex(device->touchCollectionElements, i);
+        // Koordinat verisi hiç gelmemiş koleksiyon = hayalet temas
         DispatchTouchDataForCollection(device, collection);
     }
     
@@ -610,7 +615,7 @@ static void Handle_InputValueCallback (
         device->areElementRefsSet = TRUE;
     }
     
-    //PrintInput(inIOHIDValueRef);
+    PrintInput(inIOHIDValueRef);
     IOHIDElementRef elem = IOHIDValueGetElement(inIOHIDValueRef);
     
     Boolean added = IOHIDQueueContainsElement(device->queue, elem);


### PR DESCRIPTION
## Problem

On a Waveshare 10.4" QLED capacitive touchscreen (VID `0x0712`, PID `0x000A`,
10-point HID digitizer), every finger lift spawns a phantom touch at a bogus
screen position. The phantom is visible in the debug overlay and lingers for the
0.5 s deferred-removal window. Rapid successive strokes accumulate several at
once.

## Root cause

The panel reports `ContactCount = 10` in its lift-off report instead of `0`:

```
64 | 0xd (Dig) | 0x54 (ContCnt) |  10
63 | 0xd (Dig) | 0x56 (ScnTime) |  27542
23 | 0xd (Dig) | 0x42 (Tip)     |   0
```

`DispatchTouches()` trusts that count and dispatches all ten collections.
Collections 1–9 never received any values in this report, so
`DispatchTouchDataForCollection()` leaves `x` and `y` at their `-1` sentinel and
still calls `TouchInputManagerUpdateTouchPosition()`. Each of those nine calls
creates or revives a touch at a meaningless location.

Two details make it worse on this device: it never transmits
`ContactIdentifier` at all, so every collection resolves to contact ID `0`; and
`ignoreOriginTouches` cannot help, since it tests for exact `CGPointZero` and the
sentinel is `(-1, -1)`.

The kernel-side view is clean — `evtest` on Linux shows a correct
`ABS_MT_TRACKING_ID: -1` on release — so this is purely about how the raw HID
report is interpreted.

## Fix

Bail out of `DispatchTouchDataForCollection()` when the collection produced no
coordinate values. A collection with no X/Y data should never produce a touch,
regardless of what `ContactCount` claims.

## Testing

Verified on macOS Tahoe with the panel above: phantom touches are gone, and
normal tracking, tapping, dragging and scrolling are unaffected.