### PR TITLE
Fix touches pinned to a screen corner on multi-sample digitizers (e.g. ELAN Slice20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ We used the following screens for testing:
 - 3M C4667PW
 
 
+### Troubleshooting
+If your *system* mouse jumps to a corner of the screen whenever you touch the touchscreen, your screen's firmware most likely writes the same coordinate into every sample slot of a multi-slot HID field. The resulting value exceeds the range declared in the device's descriptor, and the touch handling built into macOS misinterprets it. Touch Up reads only the first sample and is not affected, but the system mouse is controlled by macOS itself and cannot be changed from user space. In this case, enable **Exclusive Device Access** in the settings so that macOS stops processing the touchscreen — Touch Up becomes the sole handler and the system mouse no longer jumps.
 
 
 ## The *TouchUpCore* Framework

--- a/Touch Up/SettingsView.swift
+++ b/Touch Up/SettingsView.swift
@@ -101,6 +101,10 @@ struct SettingsView: View {
             Toggle(isOn: $model.areAdditionalDigitizerRotationSettingsVisible) {
                 SettingsExplanationLabel(labels: model.uiLabels(for: \.areAdditionalDigitizerRotationSettingsVisible))
             }
+            
+            Toggle(isOn: $model.isSeizingTouchDevices) {
+                SettingsExplanationLabel(labels: model.uiLabels(for: \.isSeizingTouchDevices))
+            }
         }
     }
     

--- a/Touch Up/TouchUp.swift
+++ b/Touch Up/TouchUp.swift
@@ -34,6 +34,8 @@ class TouchUp: NSObject, ObservableObject {
 
     @Published var areAdditionalDigitizerRotationSettingsVisible = false
 
+    @Published var isSeizingTouchDevices = false
+
 
     @Published var connectedScreens = [TUCScreen]()
     @Published var connectedDigitizers = [Digitizer]()
@@ -128,7 +130,8 @@ extension TouchUp {
             "isMagnificationEnabled" : true,
             "isClickWindowToFrontEnabled" : false,
             "isClickOnLiftEnabled" : false,
-            "areAdditionalDigitizerRotationSettingsVisible" : false
+            "areAdditionalDigitizerRotationSettingsVisible" : false,
+            "isSeizingTouchDevices" : false
         ])
         
         holdDuration = defaults.double(forKey: "holdDuration")
@@ -153,6 +156,14 @@ extension TouchUp {
         isClickWindowToFrontEnabled = defaults.bool(forKey: "isClickWindowToFrontEnabled")
         isClickOnLiftEnabled = defaults.bool(forKey: "isClickOnLiftEnabled")
         areAdditionalDigitizerRotationSettingsVisible = defaults.bool(forKey: "areAdditionalDigitizerRotationSettingsVisible")
+        isSeizingTouchDevices = defaults.bool(forKey: "isSeizingTouchDevices")
+        
+        // There is no backing property to assign to (the core only exposes the setTouchscreensSeized: method),
+        // so this cannot use the assign pattern above.
+        // Published re-emits its current value upon subscription, so this also applies the stored value at startup.
+        $isSeizingTouchDevices
+            .sink { self.touchManager.setTouchscreensSeized($0) }
+            .store(in: &observers)
     }
     
     
@@ -170,6 +181,7 @@ extension TouchUp {
         defaults.set(isClickWindowToFrontEnabled, forKey: "isClickWindowToFrontEnabled")
         defaults.set(isClickOnLiftEnabled, forKey: "isClickOnLiftEnabled")
         defaults.set(areAdditionalDigitizerRotationSettingsVisible, forKey: "areAdditionalDigitizerRotationSettingsVisible")
+        defaults.set(isSeizingTouchDevices, forKey: "isSeizingTouchDevices")
     }
 
 }
@@ -410,6 +422,10 @@ extension TouchUp {
         case \.areAdditionalDigitizerRotationSettingsVisible:
             return("Digitizer Rotation",
                    "Adds a rotation control to each touchscreen. Only needed if the digitizer orientation in does not match your screen.")
+            
+        case \.isSeizingTouchDevices:
+            return("Exclusive Device Access",
+                   "Touch Up opens the touchscreen exclusively, so macOS no longer processes its events. Enable this if the system mouse misbehaves, e.g. jumps to a corner of the screen.")
             
         default:
             return("\(keyPath)", "")

--- a/TouchUpCore/HIDInterpreter.c
+++ b/TouchUpCore/HIDInterpreter.c
@@ -243,9 +243,43 @@ CFIndex ValueOfElement(HIDDeviceState *device, IOHIDElementRef element) {
 
 
 
+/*!
+ Reduces the value of a multi-sample element to its first (lowest) sample.
+ 
+ Some digitizers (e.g. the ELAN "Slice20" panel) declare axis elements with a
+ report count greater than one — a field of several sample slots — and write
+ the same coordinate into every slot. For a 16-bit x 2 field the raw value
+ becomes the true coordinate multiplied by 65537, far exceeding the element's
+ logical maximum; normalizing such a value would clamp the touch to the far
+ corner of the screen. Since a multi-sample element canonically represents one
+ coordinate per sample, only the first sample is meaningful here. Elements
+ with a single sample, signed elements, or elements whose bit size does not
+ divide evenly by the count are returned unchanged.
+ */
+static CFIndex ReduceToFirstSample(IOHIDValueRef hidValue) {
+    CFIndex value = IOHIDValueGetIntegerValue(hidValue);
+    IOHIDElementRef elem = IOHIDValueGetElement(hidValue);
+    
+    uint32_t count = IOHIDElementGetReportCount(elem);
+    if (count < 2) {
+        return value;
+    }
+    
+    CFIndex sampleBits = IOHIDElementGetReportSize(elem) / count;
+    if (sampleBits <= 0 || sampleBits >= 63 || sampleBits * count != IOHIDElementGetReportSize(elem)) {
+        return value;
+    }
+    if (IOHIDElementGetLogicalMin(elem) < 0) {
+        return value;
+    }
+    
+    return value & ((1L << sampleBits) - 1);
+}
+
+
 void StoreInputValue(HIDDeviceState *device, IOHIDValueRef hidValue) {
     
-    CFIndex value = IOHIDValueGetIntegerValue(hidValue);
+    CFIndex value = ReduceToFirstSample(hidValue);
     IOHIDElementRef elem = IOHIDValueGetElement(hidValue);
     
     CFIndex keyValue = StorageKeyForElement(elem);


### PR DESCRIPTION
## Problem

On certain touchscreens, every touch lands in the **bottom-right corner** — both in the macOS system mouse and in Touch Up's DebugView. Reproduced on the ELAN "Slice20" panel (1440×960, connected via a USB-C DP dongle).

## Root cause

The panel's report descriptor declares its X/Y axis elements as **16 bit × report count 2** (a 32-bit field), but the firmware **writes the same 16-bit coordinate into both sample slots**. `IOHIDValueGetIntegerValue` then decodes the full 32-bit field, producing a value **65537× the true coordinate** (e.g. 163,580,352 = 2496 × 65537 at the right edge). A live capture of the panel confirms the low and high 16-bit words are always identical, while the low word itself tracks the finger correctly within the declared logical range.

Normalizing such a value against the element's logical maximum (2496 / 1680) saturates to (1, 1) — the bottom-right corner — in every consumer of the data: Touch Up's DebugView *and* the system mouse (handled by macOS' built-in event driver, which cannot be changed from user space).

## Changes

1. **`TouchUpCore/HIDInterpreter.c`** — `StoreInputValue` now reduces the value of multi-sample elements (report count > 1) to their **first sample**, the canonical reading of such elements. Single-sample, signed, or non-uniform elements pass through unchanged, so previously working screens are unaffected.
2. **New "Exclusive Device Access" setting** (Settings → Troubleshooting) — wires up the existing but previously unreachable `setTouchscreensSeized:` core API and persists the choice across launches. For affected screens this stops macOS from processing the touchscreen, so the system mouse no longer jumps to a corner. Default is off, so existing users are unaffected.
3. **`README.md`** — short troubleshooting note for screens whose firmware reports out-of-range coordinates.

## Verification

Built and run on macOS (Apple silicon) with the Slice20 connected: the DebugView now tracks the finger 1:1 across the whole panel (previously pinned to the bottom-right corner), and with *Exclusive Device Access* enabled the system mouse no longer jumps.
